### PR TITLE
feat: support crafter in cargo network

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,9 @@
         <spigot.version>1.21.7</spigot.version>
         <spigot.javadocs>https://hub.spigotmc.org/javadocs/spigot/</spigot.javadocs>
 
+        <!-- Testing framework -->
+        <junit.version>5.11.4</junit.version>
+
         <!-- Default settings for sonarcloud.io -->
         <sonar.projectKey>Slimefun_Slimefun4</sonar.projectKey>
         <sonar.organization>slimefun</sonar.organization>
@@ -371,6 +374,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/resources/tags/cargo_supported_storage_blocks.json
+++ b/src/main/resources/tags/cargo_supported_storage_blocks.json
@@ -1,11 +1,12 @@
 {
-  "values" : [
-    "#slimefun:shulker_boxes",
-    "minecraft:chest",
-    "minecraft:trapped_chest",
-    "minecraft:barrel",
-    "minecraft:furnace",
-    "minecraft:dispenser",
+    "values" : [
+      "#slimefun:shulker_boxes",
+      "minecraft:chest",
+      "minecraft:trapped_chest",
+      "minecraft:barrel",
+      "minecraft:crafter",
+      "minecraft:furnace",
+      "minecraft:dispenser",
     "minecraft:dropper",
     "minecraft:hopper",
     "minecraft:brewing_stand",

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/utils/tags/TestSlimefunTags.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/utils/tags/TestSlimefunTags.java
@@ -126,6 +126,14 @@ class TestSlimefunTags {
         Assertions.assertThrows(IllegalArgumentException.class, () -> SlimefunTag.getTag(null));
     }
 
+    @Test
+    @DisplayName("Crafter should be cargo-compatible")
+    void testCrafterIsCargoStorage() throws TagMisconfigurationException {
+        SlimefunTag.reloadAll();
+
+        Assertions.assertTrue(SlimefunTag.CARGO_SUPPORTED_STORAGE_BLOCKS.isTagged(Material.CRAFTER));
+    }
+
     private void assertNotCyclic(@Nonnull SlimefunTag tag) {
         Set<SlimefunTag> visiting = new HashSet<>();
         Set<SlimefunTag> visited = new HashSet<>();


### PR DESCRIPTION
## Summary
- include crafter as a cargo storage block
- specify junit version for test dependencies
- test for crafter cargo support

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: org.junit:junit-bom:pom:5.11.4 - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3b617d58832c9ccf4676d5972c3f