### PR TITLE
feat: support wind charge entity

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/compatibility/VersionedEntityType.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/compatibility/VersionedEntityType.java
@@ -16,6 +16,7 @@ public class VersionedEntityType {
     public static final EntityType ARMADILLO;
     public static final EntityType BOGGED;
     public static final EntityType BREEZE;
+    public static final EntityType WIND_CHARGE;
 
     static {
         // MUSHROOM_COW is renamed to MOOSHROOM in 1.20.5
@@ -30,6 +31,7 @@ public class VersionedEntityType {
         ARMADILLO = getKey("armadillo");
         BOGGED = getKey("bogged");
         BREEZE = getKey("breeze");
+        WIND_CHARGE = getKey("wind_charge");
     }
 
     @Nullable


### PR DESCRIPTION
## Summary
- include new WIND_CHARGE entity type in VersionedEntityType for MC 1.21

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM org.junit:junit-bom:pom:5.11.4 - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3b617d58832c9ccf4676d5972c3f