### PR TITLE
feat: add creaking entity type

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/compatibility/VersionedEntityType.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/compatibility/VersionedEntityType.java
@@ -16,6 +16,7 @@ public class VersionedEntityType {
     public static final EntityType ARMADILLO;
     public static final EntityType BOGGED;
     public static final EntityType BREEZE;
+    public static final EntityType CREAKING;
 
     static {
         // MUSHROOM_COW is renamed to MOOSHROOM in 1.20.5
@@ -30,6 +31,9 @@ public class VersionedEntityType {
         ARMADILLO = getKey("armadillo");
         BOGGED = getKey("bogged");
         BREEZE = getKey("breeze");
+
+        // Added in 1.21.2
+        CREAKING = getKey("creaking");
     }
 
     @Nullable

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/utils/TestVersionedCompatibility.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/utils/TestVersionedCompatibility.java
@@ -16,6 +16,7 @@ class TestVersionedCompatibility {
         assertNotNull(VersionedEntityType.ARMADILLO);
         assertNotNull(VersionedEntityType.BOGGED);
         assertNotNull(VersionedEntityType.BREEZE);
+        assertNotNull(VersionedEntityType.CREAKING);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add VersionedEntityType constant for the new Creaking entity introduced in recent Minecraft 1.21 updates
- cover it with a unit test

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: The following artifacts could not be resolved: org.junit:junit-bom:pom:5.11.4)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3b617d58832c9ccf4676d5972c3f