### PR TITLE
Add 1.21 particle compatibility

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/compatibility/VersionedParticle.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/compatibility/VersionedParticle.java
@@ -21,6 +21,10 @@ public class VersionedParticle {
     public static final Particle WITCH;
     public static final Particle FIREWORK;
     public static final Particle ENCHANT;
+    public static final Particle GUST;
+    public static final Particle SMALL_GUST;
+    public static final Particle GUST_EMITTER_LARGE;
+    public static final Particle GUST_EMITTER_SMALL;
 
     static {
         MinecraftVersion version = Slimefun.getMinecraftVersion();
@@ -64,6 +68,12 @@ public class VersionedParticle {
         ENCHANT = version.isAtLeast(MinecraftVersion.MINECRAFT_1_20_5)
             ? Particle.ENCHANT
             : getKey("ENCHANTMENT_TABLE");
+
+        // Added in 1.21
+        GUST = getKey("GUST");
+        SMALL_GUST = getKey("SMALL_GUST");
+        GUST_EMITTER_LARGE = getKey("GUST_EMITTER_LARGE");
+        GUST_EMITTER_SMALL = getKey("GUST_EMITTER_SMALL");
     }
 
     @Nullable

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/utils/TestVersionedCompatibility.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/utils/TestVersionedCompatibility.java
@@ -8,6 +8,7 @@ import io.github.thebusybiscuit.slimefun4.utils.compatibility.VersionedEnchantme
 import io.github.thebusybiscuit.slimefun4.utils.compatibility.VersionedEntityType;
 import io.github.thebusybiscuit.slimefun4.utils.compatibility.VersionedPotionEffectType;
 import io.github.thebusybiscuit.slimefun4.utils.compatibility.VersionedPotionType;
+import io.github.thebusybiscuit.slimefun4.utils.compatibility.VersionedParticle;
 
 class TestVersionedCompatibility {
 
@@ -39,5 +40,13 @@ class TestVersionedCompatibility {
         assertNotNull(VersionedPotionType.WEAVING);
         assertNotNull(VersionedPotionType.WIND_CHARGED);
         assertNotNull(VersionedPotionType.INFESTED);
+    }
+
+    @Test
+    void testNewParticles() {
+        assertNotNull(VersionedParticle.GUST);
+        assertNotNull(VersionedParticle.SMALL_GUST);
+        assertNotNull(VersionedParticle.GUST_EMITTER_LARGE);
+        assertNotNull(VersionedParticle.GUST_EMITTER_SMALL);
     }
 }


### PR DESCRIPTION
## Summary
- add gust and emitter particle constants for Minecraft 1.21
- test new particles in versioned compatibility tests

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM for org.junit:junit-bom)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3b617d58832c9ccf4676d5972c3f