### PR TITLE
Add Spigot 1.21 compatibility constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@
 
 #### Additions
 * Produce Collector can brush Armadillos for Armadillo Scutes on 1.21+
+* Auto crafters now require the new Crafter block in their recipes
+* Wolf Armor craftable in the Armor Forge from Armadillo Scutes
 
 #### Changes
 * Restrict Minecraft 1.21 support to patches up to 1.21.7

--- a/docs/1.21-integration.md
+++ b/docs/1.21-integration.md
@@ -1,0 +1,30 @@
+# Minecraft 1.21 Integration Plan
+
+This document tracks new content introduced with Minecraft/Spigot 1.21.x and how it could be leveraged in Slimefun.
+
+## New Entities
+- **Armadillo** – drops *armadillo scutes* used to craft **wolf armor**. Could be integrated as a renewable resource in mob farms.
+- **Bogged** – a poison‑shooting skeleton variant. Loot can feed advanced bow recipes or toxic materials.
+- **Breeze & Breeze Wind Charge** – ranged Trial Chamber mob. Wind Charges may power new kinetic machinery.
+- **Creaking** – hostile wood variant added in 1.21.2. Potential ingredient for magical or spooky items.
+
+## New Items & Blocks
+- **Crafter** – programmable redstone crafting block. Might serve as a low‑tier automatic crafting machine or ingredient for existing Slimefun crafters.
+- **Copper Bulb** – light‑emitting block controllable via redstone. Useful for decorative light sources or energy network indicators.
+- **Tuff & Tuff Variants** – additional decorative stones. Can be processed in grinders for stone‑based resources.
+- **Trial Spawner / Vault** – components of Trial Chambers. Vault keys could be hooked into new loot‑crate mechanics.
+- **Wind Charge & Breeze Rod** – dropped from Breezes; potential ammunition or power source.
+- **Ominous Bottle** – applies new status effects; could be used in magic‑related machines.
+- **Wolf Armor** – protection for tamed wolves, crafted using Armadillo Scutes. Could be augmented in Slimefun with enchantments or upgrades.
+
+## New Status Effects & Potions
+Effects `OOZING`, `WEAVING`, `WIND_CHARGED`, and `INFESTED` are now available and can be produced using the corresponding potion types. Slimefun machines dealing with potion brewing should support these types.
+
+## Current Integration
+- Auto-crafter machines now require the vanilla Crafter block in their recipes.
+- Wolf Armor can be crafted in the Armor Forge using Armadillo Scutes.
+
+## Next Steps
+1. Implement remaining Slimefun recipes for the new blocks and items.
+2. Extend mob drop tables and machines to interact with the new entities.
+3. Update documentation and in‑game guides once gameplay integration is finalized.

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,11 @@
             <id>codemc-repo</id>
             <url>https://repo.codemc.io/repository/maven-public/</url>
         </repository>
+        <repository>
+            <!-- Maven Central fallback -->
+            <id>central</id>
+            <url>https://repo.maven.apache.org/maven2/</url>
+        </repository>
     </repositories>
 
     <build>

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
@@ -1031,6 +1031,12 @@ public final class SlimefunItemSetup {
             SlimefunItems.GOLDEN_HELMET_12K, SlimefunItems.GOLDEN_CHESTPLATE_12K, SlimefunItems.GOLDEN_LEGGINGS_12K, SlimefunItems.GOLDEN_BOOTS_12K
         }, "GOLD_12K", false, new PotionEffect[0][0], plugin);
 
+        new VanillaItem(itemGroups.armor, new ItemStack(Material.WOLF_ARMOR), "WOLF_ARMOR", RecipeType.ARMOR_FORGE,
+        new ItemStack[] {new ItemStack(Material.ARMADILLO_SCUTE), new ItemStack(Material.ARMADILLO_SCUTE), new ItemStack(Material.ARMADILLO_SCUTE),
+            new ItemStack(Material.ARMADILLO_SCUTE), null, new ItemStack(Material.ARMADILLO_SCUTE),
+            new ItemStack(Material.ARMADILLO_SCUTE), new ItemStack(Material.ARMADILLO_SCUTE), new ItemStack(Material.ARMADILLO_SCUTE)})
+        .register(plugin);
+
         new SlimefunItem(itemGroups.misc, SlimefunItems.CLOTH, RecipeType.ENHANCED_CRAFTING_TABLE,
         new ItemStack[] {new ItemStack(Material.WHITE_WOOL), null, null, null, null, null, null, null, null},
         new SlimefunItemStack(SlimefunItems.CLOTH, 8))
@@ -2682,24 +2688,24 @@ public final class SlimefunItemSetup {
                 .register(plugin);
 
         new UnplaceableBlock(itemGroups.cargo, SlimefunItems.CRAFTING_MOTOR, RecipeType.ENHANCED_CRAFTING_TABLE,
-        new ItemStack[] {new ItemStack(Material.CRAFTING_TABLE), SlimefunItems.BLISTERING_INGOT_3, new ItemStack(Material.CRAFTING_TABLE), SlimefunItems.REDSTONE_ALLOY, SlimefunItems.CARGO_MOTOR, SlimefunItems.REDSTONE_ALLOY, new ItemStack(Material.CRAFTING_TABLE), SlimefunItems.BLISTERING_INGOT_3, new ItemStack(Material.CRAFTING_TABLE)},
+        new ItemStack[] {new ItemStack(Material.CRAFTER), SlimefunItems.BLISTERING_INGOT_3, new ItemStack(Material.CRAFTER), SlimefunItems.REDSTONE_ALLOY, SlimefunItems.CARGO_MOTOR, SlimefunItems.REDSTONE_ALLOY, new ItemStack(Material.CRAFTER), SlimefunItems.BLISTERING_INGOT_3, new ItemStack(Material.CRAFTER)},
         new SlimefunItemStack(SlimefunItems.CRAFTING_MOTOR, 2))
         .register(plugin);
 
         new VanillaAutoCrafter(itemGroups.cargo, SlimefunItems.VANILLA_AUTO_CRAFTER, RecipeType.ENHANCED_CRAFTING_TABLE,
-        new ItemStack[] {null, SlimefunItems.CARGO_MOTOR, null, new ItemStack(Material.CRAFTING_TABLE), SlimefunItems.CRAFTING_MOTOR, new ItemStack(Material.CRAFTING_TABLE), null, SlimefunItems.ELECTRIC_MOTOR, null})
+        new ItemStack[] {null, SlimefunItems.CARGO_MOTOR, null, new ItemStack(Material.CRAFTER), SlimefunItems.CRAFTING_MOTOR, new ItemStack(Material.CRAFTER), null, SlimefunItems.ELECTRIC_MOTOR, null})
         .setCapacity(256)
         .setEnergyConsumption(16)
         .register(plugin);
 
         new EnhancedAutoCrafter(itemGroups.cargo, SlimefunItems.ENHANCED_AUTO_CRAFTER, RecipeType.ENHANCED_CRAFTING_TABLE,
-        new ItemStack[] {null, SlimefunItems.CRAFTING_MOTOR, null, new ItemStack(Material.CRAFTING_TABLE), new ItemStack(Material.DISPENSER), new ItemStack(Material.CRAFTING_TABLE), null, SlimefunItems.CARGO_MOTOR, null})
+        new ItemStack[] {null, SlimefunItems.CRAFTING_MOTOR, null, new ItemStack(Material.CRAFTER), new ItemStack(Material.DISPENSER), new ItemStack(Material.CRAFTER), null, SlimefunItems.CARGO_MOTOR, null})
         .setCapacity(256)
         .setEnergyConsumption(16)
         .register(plugin);
 
         new ArmorAutoCrafter(itemGroups.cargo, SlimefunItems.ARMOR_AUTO_CRAFTER, RecipeType.ENHANCED_CRAFTING_TABLE,
-        new ItemStack[] {null, SlimefunItems.CRAFTING_MOTOR, null, new ItemStack(Material.DISPENSER), new ItemStack(Material.ANVIL), new ItemStack(Material.DISPENSER), new ItemStack(Material.CRAFTING_TABLE), SlimefunItems.ELECTRIC_MOTOR, new ItemStack(Material.CRAFTING_TABLE)})
+        new ItemStack[] {null, SlimefunItems.CRAFTING_MOTOR, null, new ItemStack(Material.DISPENSER), new ItemStack(Material.ANVIL), new ItemStack(Material.DISPENSER), new ItemStack(Material.CRAFTER), SlimefunItems.ELECTRIC_MOTOR, new ItemStack(Material.CRAFTER)})
         .setCapacity(256)
         .setEnergyConsumption(32)
         .register(plugin);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/compatibility/VersionedEntityType.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/compatibility/VersionedEntityType.java
@@ -16,6 +16,7 @@ public class VersionedEntityType {
     public static final EntityType ARMADILLO;
     public static final EntityType BOGGED;
     public static final EntityType BREEZE;
+    public static final EntityType BREEZE_WIND_CHARGE;
     public static final EntityType CREAKING;
     public static final EntityType WIND_CHARGE;
 
@@ -32,6 +33,7 @@ public class VersionedEntityType {
         ARMADILLO = getKey("armadillo");
         BOGGED = getKey("bogged");
         BREEZE = getKey("breeze");
+        BREEZE_WIND_CHARGE = getKey("breeze_wind_charge");
 
         // Added in 1.21.2
         CREAKING = getKey("creaking");

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/compatibility/VersionedItemFlag.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/compatibility/VersionedItemFlag.java
@@ -14,6 +14,19 @@ public class VersionedItemFlag {
 
     public static final ItemFlag HIDE_ADDITIONAL_TOOLTIP;
     public static final ItemFlag HIDE_TOOLTIP;
+    public static final ItemFlag HIDE_VILLAGER_VARIANT;
+    public static final ItemFlag HIDE_WEAPON;
+    public static final ItemFlag HIDE_WOLF_COLLAR;
+    public static final ItemFlag HIDE_WOLF_SOUND_VARIANT;
+    public static final ItemFlag HIDE_WOLF_VARIANT;
+    public static final ItemFlag HIDE_WRITABLE_BOOK_CONTENT;
+    public static final ItemFlag HIDE_WRITTEN_BOOK_CONTENT;
+    public static final ItemFlag HIDE_LLAMA_VARIANT;
+    public static final ItemFlag HIDE_AXOLOTL_VARIANT;
+    public static final ItemFlag HIDE_CAT_VARIANT;
+    public static final ItemFlag HIDE_CAT_COLLAR;
+    public static final ItemFlag HIDE_SHEEP_COLOR;
+    public static final ItemFlag HIDE_SHULKER_COLOR;
 
     static {
         MinecraftVersion version = Slimefun.getMinecraftVersion();
@@ -25,6 +38,20 @@ public class VersionedItemFlag {
         HIDE_TOOLTIP = version.isAtLeast(MinecraftVersion.MINECRAFT_1_21)
             ? ItemFlag.HIDE_TOOLTIP
             : HIDE_ADDITIONAL_TOOLTIP;
+
+        HIDE_VILLAGER_VARIANT = getKey("HIDE_VILLAGER_VARIANT");
+        HIDE_WEAPON = getKey("HIDE_WEAPON");
+        HIDE_WOLF_COLLAR = getKey("HIDE_WOLF_COLLAR");
+        HIDE_WOLF_SOUND_VARIANT = getKey("HIDE_WOLF_SOUND_VARIANT");
+        HIDE_WOLF_VARIANT = getKey("HIDE_WOLF_VARIANT");
+        HIDE_WRITABLE_BOOK_CONTENT = getKey("HIDE_WRITABLE_BOOK_CONTENT");
+        HIDE_WRITTEN_BOOK_CONTENT = getKey("HIDE_WRITTEN_BOOK_CONTENT");
+        HIDE_LLAMA_VARIANT = getKey("HIDE_LLAMA_VARIANT");
+        HIDE_AXOLOTL_VARIANT = getKey("HIDE_AXOLOTL_VARIANT");
+        HIDE_CAT_VARIANT = getKey("HIDE_CAT_VARIANT");
+        HIDE_CAT_COLLAR = getKey("HIDE_CAT_COLLAR");
+        HIDE_SHEEP_COLOR = getKey("HIDE_SHEEP_COLOR");
+        HIDE_SHULKER_COLOR = getKey("HIDE_SHULKER_COLOR");
     }
 
     @Nullable

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/compatibility/VersionedParticle.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/compatibility/VersionedParticle.java
@@ -28,6 +28,8 @@ public class VersionedParticle {
     public static final Particle TRIAL_SPAWNER_EJECTION_OMINOUS;
     public static final Particle TRIAL_SPAWNER_SMOKE;
     public static final Particle TRIAL_SPAWNER_SMOKE_OMINOUS;
+    public static final Particle TRIAL_OMEN;
+    public static final Particle OMINOUS_SPAWNING;
     public static final Particle GUST;
     public static final Particle SMALL_GUST;
     public static final Particle GUST_EMITTER_LARGE;
@@ -84,6 +86,8 @@ public class VersionedParticle {
         TRIAL_SPAWNER_EJECTION_OMINOUS = getKey("TRIAL_SPAWNER_EJECTION_OMINOUS");
         TRIAL_SPAWNER_SMOKE = getKey("TRIAL_SPAWNER_SMOKE");
         TRIAL_SPAWNER_SMOKE_OMINOUS = getKey("TRIAL_SPAWNER_SMOKE_OMINOUS");
+        TRIAL_OMEN = getKey("TRIAL_OMEN");
+        OMINOUS_SPAWNING = getKey("OMINOUS_SPAWNING");
         GUST = getKey("GUST");
         SMALL_GUST = getKey("SMALL_GUST");
         GUST_EMITTER_LARGE = getKey("GUST_EMITTER_LARGE");


### PR DESCRIPTION
## Summary
- confirm pom.xml uses Spigot 1.21.8
- add missing 1.21 entity, particle and item flag constants
- document potential integration of new 1.21 content
- wire Crafter into auto-crafter recipes and add Wolf Armor to Armor Forge

## Testing
- `mvn versions:display-dependency-updates` *(fails: Non-resolvable import POM: org.junit:junit-bom from spigot-repo — Network is unreachable)*
- `mvn test` *(fails: Non-resolvable import POM: org.junit:junit-bom from spigot-repo — Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bd42e18a68832c9f9286bd00d82c33