### PR TITLE
Add Spigot 1.21 compatibility constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 
 #### Additions
 * Produce Collector can brush Armadillos for Armadillo Scutes on 1.21+
+* Auto-Brewer can brew Oozing, Weaving, Wind Charging and Infestation potions
 
 #### Changes
 * Restrict Minecraft 1.21 support to patches up to 1.21.7

--- a/docs/1.21-integration.md
+++ b/docs/1.21-integration.md
@@ -1,0 +1,26 @@
+# Minecraft 1.21 Integration Plan
+
+This document tracks new content introduced with Minecraft/Spigot 1.21.x and how it could be leveraged in Slimefun.
+
+## New Entities
+- **Armadillo** – drops *armadillo scutes* used to craft **wolf armor**. Could be integrated as a renewable resource in mob farms.
+- **Bogged** – a poison‑shooting skeleton variant. Loot can feed advanced bow recipes or toxic materials.
+- **Breeze & Breeze Wind Charge** – ranged Trial Chamber mob. Wind Charges may power new kinetic machinery.
+- **Creaking** – hostile wood variant added in 1.21.2. Potential ingredient for magical or spooky items.
+
+## New Items & Blocks
+- **Crafter** – programmable redstone crafting block. Might serve as a low‑tier automatic crafting machine or ingredient for existing Slimefun crafters.
+- **Copper Bulb** – light‑emitting block controllable via redstone. Useful for decorative light sources or energy network indicators.
+- **Tuff & Tuff Variants** – additional decorative stones. Can be processed in grinders for stone‑based resources.
+- **Trial Spawner / Vault** – components of Trial Chambers. Vault keys could be hooked into new loot‑crate mechanics.
+- **Wind Charge & Breeze Rod** – dropped from Breezes; potential ammunition or power source.
+- **Ominous Bottle** – applies new status effects; could be used in magic‑related machines.
+- **Wolf Armor** – protection for tamed wolves, crafted using Armadillo Scutes. Could be augmented in Slimefun with enchantments or upgrades.
+
+## New Status Effects & Potions
+Effects `OOZING`, `WEAVING`, `WIND_CHARGED`, and `INFESTED` are now available and can be produced using the corresponding potion types. The Auto-Brewer accepts **Slime Blocks**, **Cobwebs**, **Breeze Rods**, and **Stone** to craft these potions automatically.
+
+## Next Steps
+1. Implement Slimefun recipes for the new blocks and items. *(Auto-Brewer covers new potions; block recipes still pending)*
+2. Extend mob drop tables and machines to interact with the new entities.
+3. Update documentation and in‑game guides once gameplay integration is finalized.

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/AutoBrewer.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/AutoBrewer.java
@@ -48,6 +48,14 @@ public class AutoBrewer extends AContainer implements NotHopperable {
         potionRecipes.put(Material.GOLDEN_CARROT, PotionType.NIGHT_VISION);
         potionRecipes.put(Material.TURTLE_HELMET, PotionType.TURTLE_MASTER);
         potionRecipes.put(Material.PHANTOM_MEMBRANE, PotionType.SLOW_FALLING);
+        potionRecipes.put(Material.SLIME_BLOCK, VersionedPotionType.OOZING);
+        potionRecipes.put(Material.COBWEB, VersionedPotionType.WEAVING);
+        potionRecipes.put(Material.STONE, VersionedPotionType.INFESTED);
+
+        Material breezeRod = Material.matchMaterial("BREEZE_ROD");
+        if (breezeRod != null) {
+            potionRecipes.put(breezeRod, VersionedPotionType.WIND_CHARGED);
+        }
 
         fermentations.put(VersionedPotionType.SWIFTNESS, PotionType.SLOWNESS);
         fermentations.put(VersionedPotionType.LEAPING, PotionType.SLOWNESS);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/compatibility/VersionedEntityType.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/compatibility/VersionedEntityType.java
@@ -16,6 +16,7 @@ public class VersionedEntityType {
     public static final EntityType ARMADILLO;
     public static final EntityType BOGGED;
     public static final EntityType BREEZE;
+    public static final EntityType BREEZE_WIND_CHARGE;
     public static final EntityType CREAKING;
     public static final EntityType WIND_CHARGE;
 
@@ -32,6 +33,7 @@ public class VersionedEntityType {
         ARMADILLO = getKey("armadillo");
         BOGGED = getKey("bogged");
         BREEZE = getKey("breeze");
+        BREEZE_WIND_CHARGE = getKey("breeze_wind_charge");
 
         // Added in 1.21.2
         CREAKING = getKey("creaking");

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/compatibility/VersionedItemFlag.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/compatibility/VersionedItemFlag.java
@@ -14,6 +14,19 @@ public class VersionedItemFlag {
 
     public static final ItemFlag HIDE_ADDITIONAL_TOOLTIP;
     public static final ItemFlag HIDE_TOOLTIP;
+    public static final ItemFlag HIDE_VILLAGER_VARIANT;
+    public static final ItemFlag HIDE_WEAPON;
+    public static final ItemFlag HIDE_WOLF_COLLAR;
+    public static final ItemFlag HIDE_WOLF_SOUND_VARIANT;
+    public static final ItemFlag HIDE_WOLF_VARIANT;
+    public static final ItemFlag HIDE_WRITABLE_BOOK_CONTENT;
+    public static final ItemFlag HIDE_WRITTEN_BOOK_CONTENT;
+    public static final ItemFlag HIDE_LLAMA_VARIANT;
+    public static final ItemFlag HIDE_AXOLOTL_VARIANT;
+    public static final ItemFlag HIDE_CAT_VARIANT;
+    public static final ItemFlag HIDE_CAT_COLLAR;
+    public static final ItemFlag HIDE_SHEEP_COLOR;
+    public static final ItemFlag HIDE_SHULKER_COLOR;
 
     static {
         MinecraftVersion version = Slimefun.getMinecraftVersion();
@@ -25,6 +38,20 @@ public class VersionedItemFlag {
         HIDE_TOOLTIP = version.isAtLeast(MinecraftVersion.MINECRAFT_1_21)
             ? ItemFlag.HIDE_TOOLTIP
             : HIDE_ADDITIONAL_TOOLTIP;
+
+        HIDE_VILLAGER_VARIANT = getKey("HIDE_VILLAGER_VARIANT");
+        HIDE_WEAPON = getKey("HIDE_WEAPON");
+        HIDE_WOLF_COLLAR = getKey("HIDE_WOLF_COLLAR");
+        HIDE_WOLF_SOUND_VARIANT = getKey("HIDE_WOLF_SOUND_VARIANT");
+        HIDE_WOLF_VARIANT = getKey("HIDE_WOLF_VARIANT");
+        HIDE_WRITABLE_BOOK_CONTENT = getKey("HIDE_WRITABLE_BOOK_CONTENT");
+        HIDE_WRITTEN_BOOK_CONTENT = getKey("HIDE_WRITTEN_BOOK_CONTENT");
+        HIDE_LLAMA_VARIANT = getKey("HIDE_LLAMA_VARIANT");
+        HIDE_AXOLOTL_VARIANT = getKey("HIDE_AXOLOTL_VARIANT");
+        HIDE_CAT_VARIANT = getKey("HIDE_CAT_VARIANT");
+        HIDE_CAT_COLLAR = getKey("HIDE_CAT_COLLAR");
+        HIDE_SHEEP_COLOR = getKey("HIDE_SHEEP_COLOR");
+        HIDE_SHULKER_COLOR = getKey("HIDE_SHULKER_COLOR");
     }
 
     @Nullable

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/compatibility/VersionedParticle.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/compatibility/VersionedParticle.java
@@ -28,6 +28,8 @@ public class VersionedParticle {
     public static final Particle TRIAL_SPAWNER_EJECTION_OMINOUS;
     public static final Particle TRIAL_SPAWNER_SMOKE;
     public static final Particle TRIAL_SPAWNER_SMOKE_OMINOUS;
+    public static final Particle TRIAL_OMEN;
+    public static final Particle OMINOUS_SPAWNING;
     public static final Particle GUST;
     public static final Particle SMALL_GUST;
     public static final Particle GUST_EMITTER_LARGE;
@@ -84,6 +86,8 @@ public class VersionedParticle {
         TRIAL_SPAWNER_EJECTION_OMINOUS = getKey("TRIAL_SPAWNER_EJECTION_OMINOUS");
         TRIAL_SPAWNER_SMOKE = getKey("TRIAL_SPAWNER_SMOKE");
         TRIAL_SPAWNER_SMOKE_OMINOUS = getKey("TRIAL_SPAWNER_SMOKE_OMINOUS");
+        TRIAL_OMEN = getKey("TRIAL_OMEN");
+        OMINOUS_SPAWNING = getKey("OMINOUS_SPAWNING");
         GUST = getKey("GUST");
         SMALL_GUST = getKey("SMALL_GUST");
         GUST_EMITTER_LARGE = getKey("GUST_EMITTER_LARGE");


### PR DESCRIPTION
## Summary
- confirm pom.xml uses Spigot 1.21.8
- add missing 1.21 entity, particle and item flag constants
- document potential integration of new 1.21 content
- allow Auto-Brewer to craft 1.21 Oozing, Weaving, Wind Charging and Infestation potions

## Testing
- `mvn -q versions:display-dependency-updates` *(fails: Non-resolvable import POM: junit-bom from spigot-repo)*
- `mvn -q test` *(fails: Non-resolvable import POM: junit-bom from spigot-repo)*

------
https://chatgpt.com/codex/tasks/task_e_68bd42e18a68832c9f9286bd00d82c33