### PR TITLE
feat: expand android drops for new mobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 * Auto crafters now require the new Crafter block in their recipes
 * Add recipes for new 1.21 blocks and armor
 * Wolf Armor craftable in the Armor Forge from Armadillo Scutes
+* Butcher Android collects Breeze Rods, Wind Charges and mushrooms from new mobs
 
 #### Changes
 * Restrict Minecraft 1.21 support to patches up to 1.21.7

--- a/docs/1.21-integration.md
+++ b/docs/1.21-integration.md
@@ -23,6 +23,7 @@ Effects `OOZING`, `WEAVING`, `WIND_CHARGED`, and `INFESTED` are now available an
 ## Current Integration
 - Auto-crafter machines now require the vanilla Crafter block in their recipes.
 - Wolf Armor can be crafted in the Armor Forge using Armadillo Scutes.
+- Butcher Android now collects Breeze Rods, Wind Charges and mushrooms from the new mobs.
 
 ## Next Steps
 1. Implement Slimefun recipes for the new blocks and items. *(Auto-Brewer covers new potions; block recipes still pending)*
@@ -34,6 +35,7 @@ Effects `OOZING`, `WEAVING`, `WIND_CHARGED`, and `INFESTED` are now available an
 - Medical supplies now cleanse the new status effects: `OOZING`, `WEAVING`, `WIND_CHARGED`, and `INFESTED`.
 - Auto-crafter machines now require the vanilla Crafter block in their recipes.
 - Wolf Armor can be crafted in the Armor Forge using Armadillo Scutes.
+- Butcher Android gathers mushrooms from Bogged and Breeze loot like Breeze Rods and Wind Charges.
 1. **Done:** Added crafting support for Crafter, Copper Bulb and Wolf Armor.
 2. Extend mob drop tables and machines to interact with the new entities.
 3. Update documentation and in‑game guides once gameplay integration is finalized.

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/ButcherAndroidListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/ButcherAndroidListener.java
@@ -23,6 +23,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.items.androids.AndroidInstance;
 import io.github.thebusybiscuit.slimefun4.implementation.items.androids.ButcherAndroid;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
+import io.github.thebusybiscuit.slimefun4.utils.compatibility.VersionedEntityType;
 
 /**
  * This {@link Listener} handles the collection of drops from an {@link Entity} that was
@@ -91,6 +92,18 @@ public class ButcherAndroidListener implements Listener {
 
         if (entityType == EntityType.VINDICATOR) {
             drops.add(new ItemStack(Material.EMERALD, 1 + random.nextInt(2)));
+        }
+
+        if (entityType == VersionedEntityType.BOGGED) {
+            drops.add(new ItemStack(Material.BROWN_MUSHROOM, 1 + random.nextInt(2)));
+            drops.add(new ItemStack(Material.RED_MUSHROOM, 1 + random.nextInt(2)));
+        }
+
+        if (entityType == VersionedEntityType.BREEZE) {
+            drops.add(new ItemStack(Material.BREEZE_ROD));
+            if (random.nextInt(3) == 0) {
+                drops.add(new ItemStack(Material.WIND_CHARGE));
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure Butcher Android drops Breeze Rods, Wind Charges, and mushrooms from new 1.21 mobs
- document new drop integrations in 1.21 plan
- note new drops in changelog

## Testing
- `mvn -e test` *(failed: hang while downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5258afe8832cb226ac5e057b6eae