### PR TITLE
feat: add Breeze Rod mob drop

### DIFF
--- a/docs/1.21-integration.md
+++ b/docs/1.21-integration.md
@@ -34,8 +34,9 @@ Effects `OOZING`, `WEAVING`, `WIND_CHARGED`, and `INFESTED` are now available an
 - Medical supplies now cleanse the new status effects: `OOZING`, `WEAVING`, `WIND_CHARGED`, and `INFESTED`.
 - Auto-crafter machines now require the vanilla Crafter block in their recipes.
 - Wolf Armor can be crafted in the Armor Forge using Armadillo Scutes.
+- Breezes drop **Breeze Rods** as custom mob drops for Slimefun.
 1. **Done:** Added crafting support for Crafter, Copper Bulb and Wolf Armor.
-2. Extend mob drop tables and machines to interact with the new entities.
+2. Extend mob drop tables and machines to interact with the remaining new entities.
 3. Update documentation and in‑game guides once gameplay integration is finalized.
 
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunItems.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunItems.java
@@ -65,6 +65,7 @@ public final class SlimefunItems {
     public static final SlimefunItemStack MAGICAL_ZOMBIE_PILLS = new SlimefunItemStack("MAGICAL_ZOMBIE_PILLS", Material.NETHER_WART, "&6Magical Zombie Pills", "", "&eRight Click &7a Zombified Villager", "&eor &7a Zombified Piglin to", "&7instantly cure it from its curse");
 
     public static final SlimefunItemStack WOLF_ARMOR = new SlimefunItemStack("WOLF_ARMOR", Material.WOLF_ARMOR, "&6Wolf Armor");
+    public static final SlimefunItemStack BREEZE_ROD = new SlimefunItemStack("BREEZE_ROD", Material.BREEZE_ROD, "&bBreeze Rod");
 
     public static final SlimefunItemStack FLASK_OF_KNOWLEDGE = new SlimefunItemStack("FLASK_OF_KNOWLEDGE", Material.GLASS_BOTTLE, "&cFlask of Knowledge", "", "&fAllows you to store some of", "&fyour Experience in a Bottle", "&7Cost: &a1 Level");
     public static final SlimefunItemStack FILLED_FLASK_OF_KNOWLEDGE = new SlimefunItemStack("FILLED_FLASK_OF_KNOWLEDGE", Material.EXPERIENCE_BOTTLE, "&aFlask of Knowledge");

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
@@ -2113,6 +2113,10 @@ public final class SlimefunItemSetup {
             null, new ItemStack(Material.COPPER_BLOCK), null})
         .register(plugin);
 
+        new VanillaItem(itemGroups.magicalResources, SlimefunItems.BREEZE_ROD, "BREEZE_ROD", RecipeType.MOB_DROP,
+        new ItemStack[] {null, null, null, null, new CustomItemStack(new ItemStack(Material.BREEZE_SPAWN_EGG), "&aBreeze"), null, null, null, null})
+        .register(plugin);
+
         new VanillaItem(itemGroups.armor, new ItemStack(Material.WOLF_ARMOR), "WOLF_ARMOR", RecipeType.ARMOR_FORGE,
         new ItemStack[] {new ItemStack(Material.ARMADILLO_SCUTE), new ItemStack(Material.ARMADILLO_SCUTE), new ItemStack(Material.ARMADILLO_SCUTE),
             null, new ItemStack(Material.ARMADILLO_SCUTE), null,


### PR DESCRIPTION
## Summary
- register Breeze Rod as a mob drop from Breezes
- document Breeze Rod integration in 1.21 plan

## Testing
- `mvn -q test` *(fails: package be.seeseemelk.mockbukkit does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5258afe8832cb226ac5e057b6eae