### PR TITLE
feat: add armadillo scutes to butcher android drops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@
 * Auto crafters now require the new Crafter block in their recipes
 * Add recipes for new 1.21 blocks and armor
 * Wolf Armor craftable in the Armor Forge from Armadillo Scutes
-* Butcher Android collects Breeze Rods, Wind Charges and mushrooms from new mobs
+* Butcher Android collects Armadillo Scutes, Breeze Rods, Wind Charges and mushrooms from new mobs
 
 #### Changes
 * Restrict Minecraft 1.21 support to patches up to 1.21.7

--- a/docs/1.21-integration.md
+++ b/docs/1.21-integration.md
@@ -23,7 +23,7 @@ Effects `OOZING`, `WEAVING`, `WIND_CHARGED`, and `INFESTED` are now available an
 ## Current Integration
 - Auto-crafter machines now require the vanilla Crafter block in their recipes.
 - Wolf Armor can be crafted in the Armor Forge using Armadillo Scutes.
-- Butcher Android now collects Breeze Rods, Wind Charges and mushrooms from the new mobs.
+- Butcher Android now collects Armadillo Scutes, Breeze Rods, Wind Charges and mushrooms from the new mobs.
 
 ## Next Steps
 1. Implement Slimefun recipes for the new blocks and items. *(Auto-Brewer covers new potions; block recipes still pending)*
@@ -36,10 +36,6 @@ Effects `OOZING`, `WEAVING`, `WIND_CHARGED`, and `INFESTED` are now available an
 - Auto-crafter machines now require the vanilla Crafter block in their recipes.
 - Wolf Armor can be crafted in the Armor Forge using Armadillo Scutes.
 - Breezes drop **Breeze Rods** as custom mob drops for Slimefun.
-=======
-- Butcher Android gathers mushrooms from Bogged and Breeze loot like Breeze Rods and Wind Charges.
-1. **Done:** Added crafting support for Crafter, Copper Bulb and Wolf Armor.
-2. Extend mob drop tables and machines to interact with the remaining new entities.
-3. Update documentation and in‑game guides once gameplay integration is finalized.
+- Butcher Android gathers Armadillo Scutes, mushrooms from Bogged, and Breeze loot like Breeze Rods and Wind Charges.
 
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/ButcherAndroidListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/ButcherAndroidListener.java
@@ -99,6 +99,10 @@ public class ButcherAndroidListener implements Listener {
             drops.add(new ItemStack(Material.RED_MUSHROOM, 1 + random.nextInt(2)));
         }
 
+        if (entityType == VersionedEntityType.ARMADILLO) {
+            drops.add(new ItemStack(Material.ARMADILLO_SCUTE, 1 + random.nextInt(2)));
+        }
+
         if (entityType == VersionedEntityType.BREEZE) {
             drops.add(new ItemStack(Material.BREEZE_ROD));
             if (random.nextInt(3) == 0) {


### PR DESCRIPTION
## Summary
- allow Butcher Androids to harvest Armadillo Scutes
- document Armadillo Scute integration with Butcher Android
- note new drop support in changelog

## Testing
- `mvn -q -ntp test` *(fails: package be.seeseemelk.mockbukkit does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68bd544e64f8832c91fcc19704ae7217