### PR TITLE
Allow tuff variants in ore grinder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 * Auto crafters now require the new Crafter block in their recipes
 * Add recipes for new 1.21 blocks and armor
 * Wolf Armor craftable in the Armor Forge from Armadillo Scutes
+* Ore Crusher and Electric Ore Grinder can crush Tuff and its variants into Sand
 
 * Butcher Android collects Breeze Rods, Wind Charges and mushrooms from new mobs
 * Butcher Android collects Creaking Hearts from Creakings

--- a/docs/1.21-integration.md
+++ b/docs/1.21-integration.md
@@ -23,9 +23,10 @@ Effects `OOZING`, `WEAVING`, `WIND_CHARGED`, and `INFESTED` are now available an
 ## Current Integration
 - Auto-crafter machines now require the vanilla Crafter block in their recipes.
 - Wolf Armor can be crafted in the Armor Forge using Armadillo Scutes.
+- Tuff and its variants can be crushed into sand by the Ore Crusher and Electric Ore Grinder.
 
 ## Next Steps
-1. Implement Slimefun recipes for the remaining new blocks and items (e.g., Tuff variants, Trial Spawner components, Ominous Bottle).
+1. Implement Slimefun recipes for the remaining new blocks and items (e.g., Trial Spawner components, Ominous Bottle).
 2. Extend mob drop tables and machines to interact with remaining entities such as the Creaking.
 3. Update documentation and in-game guides once gameplay integration is finalized.
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/OreCrusher.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/OreCrusher.java
@@ -107,6 +107,25 @@ public class OreCrusher extends MultiBlockMachine {
             recipes.add(new ItemStack(Material.COBBLED_DEEPSLATE, 8));
             recipes.add(new ItemStack(Material.SAND, 1));
         }
+
+        // Tuff and its variants can be crushed into sand
+        recipes.add(new ItemStack(Material.TUFF, 8));
+        recipes.add(new ItemStack(Material.SAND, 1));
+
+        String[] tuffVariants = {
+            "POLISHED_TUFF",
+            "TUFF_BRICKS",
+            "POLISHED_TUFF_BRICKS",
+            "CHISELED_TUFF",
+            "CHISELED_TUFF_BRICKS"
+        };
+        for (String variant : tuffVariants) {
+            Material mat = Material.matchMaterial(variant);
+            if (mat != null) {
+                recipes.add(new ItemStack(mat, 8));
+                recipes.add(new ItemStack(Material.SAND, 1));
+            }
+        }
     }
 
     public boolean isOreDoublingEnabled() {


### PR DESCRIPTION
## Summary
- Let the Ore Crusher and Electric Ore Grinder crush tuff and its new variants into sand
- Document tuff crushing integration and update pending integration tasks
- Note tuff recipes in the changelog

## Testing
- `mvn -q test` *(fails: package be.seeseemelk.mockbukkit.inventory does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68bd56e60708832cba20978785eb4a8a