### PR TITLE
Expand Minecraft 1.21 integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,11 @@
 * Auto crafters now require the new Crafter block in their recipes
 * Add recipes for new 1.21 blocks and armor
 * Wolf Armor craftable in the Armor Forge from Armadillo Scutes
+* Copper Bulb craftable in the Enhanced Crafting Table
+* Ominous Bottle craftable in the Magic Workbench
+* Trial Key craftable in the Magic Workbench
+* Vault and Trial Spawner craftable in the Enhanced Crafting Table
+* Ore Crusher and Electric Ore Grinder can crush Tuff and its variants into Sand
 
 * Butcher Android collects Breeze Rods, Wind Charges and mushrooms from new mobs
 * Butcher Android collects Creaking Hearts from Creakings

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ But it also comes with a lot of addons! Check out our [addons](https://github.co
 
 ### Support for Minecraft 1.21
 Slimefun now targets Spigot **1.21.x**. The plugin recognises new entities like Armadillos, Bogged, Breezes and Creakings and handles fresh potion effects and enchantments such as Oozing, Weaving, Wind Charged, Density, Breach and Wind Burst.
-These additions integrate seamlessly with existing mechanics, allowing you to craft recipes and machines that interact with the latest vanilla content.
+These additions integrate seamlessly with existing mechanics, allowing you to craft recipes and machines that interact with the latest vanilla content. You can craft the Crafter, Copper Bulb, Ominous Bottle, Trial Key, Vault and Trial Spawner, grind Tuff variants into sand and harvest new mob drops with Slimefun automation.
 
 ### Quick navigation
 * **[:floppy_disk: Download Slimefun4](#floppy_disk-download-slimefun-4)**

--- a/docs/1.21-integration.md
+++ b/docs/1.21-integration.md
@@ -23,9 +23,16 @@ Effects `OOZING`, `WEAVING`, `WIND_CHARGED`, and `INFESTED` are now available an
 ## Current Integration
 - Auto-crafter machines now require the vanilla Crafter block in their recipes.
 - Wolf Armor can be crafted in the Armor Forge using Armadillo Scutes.
+- Tuff and its variants can be crushed into sand by the Ore Crusher and Electric Ore Grinder.
+- Auto-Brewer can brew Oozing, Weaving, Wind Charging and Infestation potions.
+- Produce Collector can brush Armadillos for Armadillo Scutes.
+- Butcher Android harvests Breeze Rods, Wind Charges, mushrooms from Bogged, and Creaking Hearts.
+- Copper Bulb can be crafted in the Enhanced Crafting Table.
+- Ominous Bottle can be crafted in the Magic Workbench.
+- Trial Key can be crafted in the Magic Workbench.
+- Vault and Trial Spawner can be crafted in the Enhanced Crafting Table.
 
 ## Next Steps
-1. Implement Slimefun recipes for the remaining new blocks and items (e.g., Tuff variants, Trial Spawner components, Ominous Bottle).
-2. Extend mob drop tables and machines to interact with remaining entities such as the Creaking.
-3. Update documentation and in-game guides once gameplay integration is finalized.
+1. Finalize mob drop tables and machine interactions for any remaining 1.21 entities.
+2. Update documentation and in-game guides once gameplay integration is finalized.
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/OreCrusher.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/OreCrusher.java
@@ -107,6 +107,25 @@ public class OreCrusher extends MultiBlockMachine {
             recipes.add(new ItemStack(Material.COBBLED_DEEPSLATE, 8));
             recipes.add(new ItemStack(Material.SAND, 1));
         }
+
+        // Tuff and its variants can be crushed into sand
+        recipes.add(new ItemStack(Material.TUFF, 8));
+        recipes.add(new ItemStack(Material.SAND, 1));
+
+        String[] tuffVariants = {
+            "POLISHED_TUFF",
+            "TUFF_BRICKS",
+            "POLISHED_TUFF_BRICKS",
+            "CHISELED_TUFF",
+            "CHISELED_TUFF_BRICKS"
+        };
+        for (String variant : tuffVariants) {
+            Material mat = Material.matchMaterial(variant);
+            if (mat != null) {
+                recipes.add(new ItemStack(mat, 8));
+                recipes.add(new ItemStack(Material.SAND, 1));
+            }
+        }
     }
 
     public boolean isOreDoublingEnabled() {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
@@ -1037,12 +1037,6 @@ public final class SlimefunItemSetup {
             SlimefunItems.GOLDEN_HELMET_12K, SlimefunItems.GOLDEN_CHESTPLATE_12K, SlimefunItems.GOLDEN_LEGGINGS_12K, SlimefunItems.GOLDEN_BOOTS_12K
         }, "GOLD_12K", false, new PotionEffect[0][0], plugin);
 
-        new VanillaItem(itemGroups.armor, new ItemStack(Material.WOLF_ARMOR), "WOLF_ARMOR", RecipeType.ARMOR_FORGE,
-        new ItemStack[] {new ItemStack(Material.ARMADILLO_SCUTE), new ItemStack(Material.ARMADILLO_SCUTE), new ItemStack(Material.ARMADILLO_SCUTE),
-            new ItemStack(Material.ARMADILLO_SCUTE), null, new ItemStack(Material.ARMADILLO_SCUTE),
-            new ItemStack(Material.ARMADILLO_SCUTE), new ItemStack(Material.ARMADILLO_SCUTE), new ItemStack(Material.ARMADILLO_SCUTE)})
-        .register(plugin);
-
         new SlimefunItem(itemGroups.misc, SlimefunItems.CLOTH, RecipeType.ENHANCED_CRAFTING_TABLE,
         new ItemStack[] {new ItemStack(Material.WHITE_WOOL), null, null, null, null, null, null, null, null},
         new SlimefunItemStack(SlimefunItems.CLOTH, 8))
@@ -2115,6 +2109,30 @@ public final class SlimefunItemSetup {
 
         new VanillaItem(itemGroups.magicalResources, SlimefunItems.BREEZE_ROD, "BREEZE_ROD", RecipeType.MOB_DROP,
         new ItemStack[] {null, null, null, null, new CustomItemStack(new ItemStack(Material.BREEZE_SPAWN_EGG), "&aBreeze"), null, null, null, null})
+        .register(plugin);
+
+        new VanillaItem(itemGroups.magicalResources, new ItemStack(Material.OMINOUS_BOTTLE), "OMINOUS_BOTTLE", RecipeType.MAGIC_WORKBENCH,
+        new ItemStack[] {new ItemStack(Material.COBWEB), new ItemStack(Material.BREEZE_ROD), new ItemStack(Material.COBWEB),
+            new ItemStack(Material.SLIME_BALL), new ItemStack(Material.GLASS_BOTTLE), new ItemStack(Material.SLIME_BALL),
+            null, new ItemStack(Material.FERMENTED_SPIDER_EYE), null})
+        .register(plugin);
+
+        new VanillaItem(itemGroups.magicalResources, new ItemStack(Material.TRIAL_KEY), "TRIAL_KEY", RecipeType.MAGIC_WORKBENCH,
+        new ItemStack[] {new ItemStack(Material.GOLD_INGOT), SlimefunItems.BREEZE_ROD, new ItemStack(Material.GOLD_INGOT),
+            null, new ItemStack(Material.TRIPWIRE_HOOK), null,
+            null, new ItemStack(Material.IRON_INGOT), null})
+        .register(plugin);
+
+        new VanillaItem(itemGroups.basicMachines, new ItemStack(Material.VAULT), "VAULT", RecipeType.ENHANCED_CRAFTING_TABLE,
+        new ItemStack[] {new ItemStack(Material.COPPER_BLOCK), new ItemStack(Material.IRON_BARS), new ItemStack(Material.COPPER_BLOCK),
+            new ItemStack(Material.IRON_BARS), new ItemStack(Material.CHEST), new ItemStack(Material.IRON_BARS),
+            new ItemStack(Material.COPPER_BLOCK), new ItemStack(Material.IRON_BARS), new ItemStack(Material.COPPER_BLOCK)})
+        .register(plugin);
+
+        new VanillaItem(itemGroups.basicMachines, new ItemStack(Material.TRIAL_SPAWNER), "TRIAL_SPAWNER", RecipeType.ENHANCED_CRAFTING_TABLE,
+        new ItemStack[] {new ItemStack(Material.DEEPSLATE_BRICKS), SlimefunItems.BREEZE_ROD, new ItemStack(Material.DEEPSLATE_BRICKS),
+            new ItemStack(Material.IRON_BARS), new ItemStack(Material.SPAWNER), new ItemStack(Material.IRON_BARS),
+            new ItemStack(Material.DEEPSLATE_BRICKS), new ItemStack(Material.TRIAL_KEY), new ItemStack(Material.DEEPSLATE_BRICKS)})
         .register(plugin);
 
         new VanillaItem(itemGroups.armor, new ItemStack(Material.WOLF_ARMOR), "WOLF_ARMOR", RecipeType.ARMOR_FORGE,


### PR DESCRIPTION
## Summary
- Add Magic Workbench recipe for the Trial Key
- Add Enhanced Crafting Table recipes for Vault and Trial Spawner and document their integration
- Update README and changelog for new Trial Chamber items

## Testing
- `mvn -e test` *(fails: package be.seeseemelk.mockbukkit does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68bd56e60708832cba20978785eb4a8a