### PR TITLE
feat: add heavy core and mace recipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@
 * Ominous Bottle craftable in the Magic Workbench
 * Trial Key craftable in the Magic Workbench
 * Vault and Trial Spawner craftable in the Enhanced Crafting Table
+* Heavy Core craftable in the Enhanced Crafting Table
+* Mace craftable in the Enhanced Crafting Table from a Breeze Rod and Heavy Core
 * Ore Crusher and Electric Ore Grinder can crush Tuff and its variants into Sand
 
 * Butcher Android collects Breeze Rods, Wind Charges and mushrooms from new mobs

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ But it also comes with a lot of addons! Check out our [addons](https://github.co
 ### Support for Minecraft 1.21
 Slimefun now targets Spigot **1.21.x**. The plugin recognises new entities like Armadillos, Bogged, Breezes and Creakings and handles fresh potion effects and enchantments such as Oozing, Weaving, Wind Charged, Density, Breach and Wind Burst.
 
-These additions integrate seamlessly with existing mechanics, allowing you to craft recipes and machines that interact with the latest vanilla content. You can automatically brew Oozing, Weaving, Wind Charging and Infestation potions, brush Armadillos for Scutes to craft Wolf Armor, harvest Breeze Rods, Wind Charges, mushrooms and Creaking Hearts with the Butcher Android, craft the Crafter, Copper Bulb, Ominous Bottle, Trial Key, Vault and Trial Spawner, and grind Tuff variants into sand.
+These additions integrate seamlessly with existing mechanics, allowing you to craft recipes and machines that interact with the latest vanilla content. You can automatically brew Oozing, Weaving, Wind Charging and Infestation potions, brush Armadillos for Scutes to craft Wolf Armor, harvest Breeze Rods, Wind Charges, mushrooms and Creaking Hearts with the Butcher Android, craft the Crafter, Copper Bulb, Ominous Bottle, Trial Key, Heavy Core, Mace, Vault and Trial Spawner, and grind Tuff variants into sand.
 
 
 ### Quick navigation

--- a/docs/1.21-integration.md
+++ b/docs/1.21-integration.md
@@ -15,6 +15,7 @@ This document tracks new content introduced with Minecraft/Spigot 1.21.x and how
 - **Trial Spawner / Vault** – components of Trial Chambers. Vault keys could be hooked into new loot-crate mechanics.
 - **Wind Charge & Breeze Rod** – dropped from Breezes; potential ammunition or power source.
 - **Ominous Bottle** – applies new status effects; could be used in magic-related machines.
+- **Heavy Core & Mace** – heavy weapon components from Trial Chambers. The Mace is forged from a Heavy Core and Breeze Rod.
 - **Wolf Armor** – protection for tamed wolves, crafted using Armadillo Scutes. Could be augmented in Slimefun with enchantments or upgrades.
 
 ## New Status Effects & Potions
@@ -31,6 +32,8 @@ Effects `OOZING`, `WEAVING`, `WIND_CHARGED`, and `INFESTED` are now available an
 - Ominous Bottle can be crafted in the Magic Workbench.
 - Trial Key can be crafted in the Magic Workbench.
 - Vault and Trial Spawner can be crafted in the Enhanced Crafting Table.
+- Heavy Core can be crafted in the Enhanced Crafting Table.
+- Mace can be crafted in the Enhanced Crafting Table using a Heavy Core and Breeze Rod.
 
 ## Next Steps
 1. Finalize mob drop tables and machine interactions for any remaining 1.21 entities.

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunItems.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunItems.java
@@ -66,6 +66,8 @@ public final class SlimefunItems {
 
     public static final SlimefunItemStack WOLF_ARMOR = new SlimefunItemStack("WOLF_ARMOR", Material.WOLF_ARMOR, "&6Wolf Armor");
     public static final SlimefunItemStack BREEZE_ROD = new SlimefunItemStack("BREEZE_ROD", Material.BREEZE_ROD, "&bBreeze Rod");
+    public static final SlimefunItemStack HEAVY_CORE = new SlimefunItemStack("HEAVY_CORE", Material.HEAVY_CORE, "&6Heavy Core");
+    public static final SlimefunItemStack MACE = new SlimefunItemStack("MACE", Material.MACE, "&6Mace");
 
     public static final SlimefunItemStack FLASK_OF_KNOWLEDGE = new SlimefunItemStack("FLASK_OF_KNOWLEDGE", Material.GLASS_BOTTLE, "&cFlask of Knowledge", "", "&fAllows you to store some of", "&fyour Experience in a Bottle", "&7Cost: &a1 Level");
     public static final SlimefunItemStack FILLED_FLASK_OF_KNOWLEDGE = new SlimefunItemStack("FILLED_FLASK_OF_KNOWLEDGE", Material.EXPERIENCE_BOTTLE, "&aFlask of Knowledge");

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
@@ -2129,6 +2129,18 @@ public final class SlimefunItemSetup {
             new ItemStack(Material.DEEPSLATE_BRICKS), new ItemStack(Material.TRIAL_KEY), new ItemStack(Material.DEEPSLATE_BRICKS)})
         .register(plugin);
 
+        new VanillaItem(itemGroups.magicalResources, new ItemStack(Material.HEAVY_CORE), "HEAVY_CORE", RecipeType.ENHANCED_CRAFTING_TABLE,
+        new ItemStack[] {new ItemStack(Material.IRON_BLOCK), new ItemStack(Material.IRON_BLOCK), new ItemStack(Material.IRON_BLOCK),
+            new ItemStack(Material.IRON_BLOCK), new ItemStack(Material.NETHERITE_INGOT), new ItemStack(Material.IRON_BLOCK),
+            new ItemStack(Material.IRON_BLOCK), new ItemStack(Material.IRON_BLOCK), new ItemStack(Material.IRON_BLOCK)})
+        .register(plugin);
+
+        new VanillaItem(itemGroups.weapons, new ItemStack(Material.MACE), "MACE", RecipeType.ENHANCED_CRAFTING_TABLE,
+        new ItemStack[] {null, SlimefunItems.BREEZE_ROD, null,
+            null, SlimefunItems.HEAVY_CORE, null,
+            null, null, null})
+        .register(plugin);
+
         new VanillaItem(itemGroups.armor, new ItemStack(Material.WOLF_ARMOR), "WOLF_ARMOR", RecipeType.ARMOR_FORGE,
         new ItemStack[] {new ItemStack(Material.ARMADILLO_SCUTE), new ItemStack(Material.ARMADILLO_SCUTE), new ItemStack(Material.ARMADILLO_SCUTE),
             null, new ItemStack(Material.ARMADILLO_SCUTE), null,


### PR DESCRIPTION
## Summary
- add Heavy Core and Mace items for Minecraft 1.21
- register Heavy Core and Mace vanilla recipes
- document new Heavy Core and Mace integration

## Testing
- `mvn -e test` *(fails: terminated during dependency resolution)*

------
https://chatgpt.com/codex/tasks/task_e_68bd60f515a0832c969c7074d26b4553