### PR TITLE
chore: update 1.21 integration

### DIFF
--- a/.github/workflows/e2e-testing.yml
+++ b/.github/workflows/e2e-testing.yml
@@ -29,7 +29,7 @@ jobs:
             javaVersion: '20'
           - mcVersion: '1.20.6'
             javaVersion: '21'
-          - mcVersion: '1.21.7'
+          - mcVersion: '1.21.8'
             javaVersion: '21'
           #- mcVersion: 'latest'
           #  javaVersion: '21'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@
 
 
 #### Changes
-* Restrict Minecraft 1.21 support to patches up to 1.21.7
+* Restrict Minecraft 1.21 support to patches up to 1.21.8
 
 ## Release Candidate 37 (25 Feb 2024)
 

--- a/docs/sop/update.md
+++ b/docs/sop/update.md
@@ -15,7 +15,7 @@ The first step is just updating Spigot in the pom.xml. This should only be done 
 * There's a new major version (well, MC major - 1.20 -> 1.21 is a major)
 * There was a change within MC or Bukkit/Spigot that broke the API
 
-To update the Spigot version, you will need to go to the `pom.xml` and find the `spigot.version` property, this will be within the `properties` property. Simply make this the MC version (e.g. `1.21` or in the case of minor `1.21.7`).
+To update the Spigot version, you will need to go to the `pom.xml` and find the `spigot.version` property, this will be within the `properties` property. Simply make this the MC version (e.g. `1.21` or in the case of minor `1.21.8`).
 
 Once updated, **make sure to run a build** to check for compilation failures with `mvn clean package -DskipTests=true`. We will go over the tests next.
 

--- a/pom.xml
+++ b/pom.xml
@@ -409,7 +409,7 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.21.7-R0.1-SNAPSHOT</version>
+            <version>1.21.8-R0.1-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/MinecraftVersion.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/MinecraftVersion.java
@@ -60,7 +60,7 @@ public enum MinecraftVersion {
      * ("The Tricky Trials Update")
      */
 
-    MINECRAFT_1_21(21, 0, 7, "1.21.x"),
+    MINECRAFT_1_21(21, 0, 8, "1.21.x"),
 
 
     /**


### PR DESCRIPTION
## Summary
- track Minecraft 1.21.8 patch
- update CI matrix and test dependencies

## Testing
- `mvn -q -e test` *(fails: package be.seeseemelk.mockbukkit does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68bd60f515a0832c969c7074d26b4553