### PR TITLE
Expand 1.21 integration coverage

### DIFF
--- a/docs/1.21-integration.md
+++ b/docs/1.21-integration.md
@@ -27,6 +27,7 @@ Effects `OOZING`, `WEAVING`, `WIND_CHARGED`, and `INFESTED` are now available an
 - Auto-Brewer can brew Oozing, Weaving, Wind Charging and Infestation potions.
 - Produce Collector can brush Armadillos for Armadillo Scutes.
 - Butcher Android harvests Breeze Rods, Wind Charges, mushrooms from Bogged, and Creaking Hearts.
+- Medical Supplies cure Oozing, Weaving, Wind Charged and Infested effects.
 - Copper Bulb can be crafted in the Enhanced Crafting Table.
 - Ominous Bottle can be crafted in the Magic Workbench.
 - Trial Key can be crafted in the Magic Workbench.

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/TestAutoBrewerPotions.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/TestAutoBrewerPotions.java
@@ -1,0 +1,40 @@
+package io.github.thebusybiscuit.slimefun4.implementation.items.electric.machines;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import org.bukkit.Material;
+import org.bukkit.potion.PotionType;
+import org.junit.jupiter.api.Test;
+
+import io.github.thebusybiscuit.slimefun4.implementation.items.electric.machines.AutoBrewer;
+import io.github.thebusybiscuit.slimefun4.utils.compatibility.VersionedPotionType;
+
+class TestAutoBrewerPotions {
+
+    @SuppressWarnings("unchecked")
+    private Map<Material, PotionType> getPotionRecipes() throws Exception {
+        Field field = AutoBrewer.class.getDeclaredField("potionRecipes");
+        field.setAccessible(true);
+        return (Map<Material, PotionType>) field.get(null);
+    }
+
+    @Test
+    void testNewPotionRecipes() throws Exception {
+        Map<Material, PotionType> recipes = getPotionRecipes();
+
+        assertEquals(VersionedPotionType.OOZING, recipes.get(Material.SLIME_BLOCK));
+        assertEquals(VersionedPotionType.WEAVING, recipes.get(Material.COBWEB));
+        assertEquals(VersionedPotionType.INFESTED, recipes.get(Material.STONE));
+
+        Material breezeRod = Material.matchMaterial("BREEZE_ROD");
+        if (breezeRod != null) {
+            assertEquals(VersionedPotionType.WIND_CHARGED, recipes.get(breezeRod));
+        } else {
+            assertNotNull(breezeRod, "BREEZE_ROD material should exist on 1.21");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- document that Medical Supplies cure new 1.21 status effects
- add unit test ensuring AutoBrewer brews 1.21 potions from slime blocks, cobwebs, stone and breeze rods

## Testing
- `mvn -q -o test` *(fails: Non-resolvable import POM: junit-bom)*
- `mvn -q test` *(hangs waiting for proxy, terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68bd60f515a0832c969c7074d26b4553