### PR TITLE
Register vanilla items for new 1.21 drops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 
 * Butcher Android collects Breeze Rods, Wind Charges and mushrooms from new mobs
 * Butcher Android collects Creaking Hearts from Creakings
+* Wind Charges, Armadillo Scutes and Creaking Hearts are listed as vanilla items in the Slimefun guide
 
 
 #### Changes

--- a/docs/1.21-integration.md
+++ b/docs/1.21-integration.md
@@ -27,6 +27,7 @@ Effects `OOZING`, `WEAVING`, `WIND_CHARGED`, and `INFESTED` are now available an
 - Auto-Brewer can brew Oozing, Weaving, Wind Charging and Infestation potions.
 - Produce Collector can brush Armadillos for Armadillo Scutes.
 - Butcher Android harvests Breeze Rods, Wind Charges, mushrooms from Bogged, and Creaking Hearts.
+- Wind Charges, Armadillo Scutes and Creaking Hearts appear as vanilla items in the Slimefun guide.
 - Copper Bulb can be crafted in the Enhanced Crafting Table.
 - Ominous Bottle can be crafted in the Magic Workbench.
 - Trial Key can be crafted in the Magic Workbench.

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunItems.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunItems.java
@@ -66,6 +66,9 @@ public final class SlimefunItems {
 
     public static final SlimefunItemStack WOLF_ARMOR = new SlimefunItemStack("WOLF_ARMOR", Material.WOLF_ARMOR, "&6Wolf Armor");
     public static final SlimefunItemStack BREEZE_ROD = new SlimefunItemStack("BREEZE_ROD", Material.BREEZE_ROD, "&bBreeze Rod");
+    public static final SlimefunItemStack WIND_CHARGE = new SlimefunItemStack("WIND_CHARGE", Material.WIND_CHARGE, "&bWind Charge");
+    public static final SlimefunItemStack ARMADILLO_SCUTE = new SlimefunItemStack("ARMADILLO_SCUTE", Material.ARMADILLO_SCUTE, "&6Armadillo Scute");
+    public static final SlimefunItemStack CREAKING_HEART = new SlimefunItemStack("CREAKING_HEART", Material.CREAKING_HEART, "&cCreaking Heart");
 
     public static final SlimefunItemStack FLASK_OF_KNOWLEDGE = new SlimefunItemStack("FLASK_OF_KNOWLEDGE", Material.GLASS_BOTTLE, "&cFlask of Knowledge", "", "&fAllows you to store some of", "&fyour Experience in a Bottle", "&7Cost: &a1 Level");
     public static final SlimefunItemStack FILLED_FLASK_OF_KNOWLEDGE = new SlimefunItemStack("FILLED_FLASK_OF_KNOWLEDGE", Material.EXPERIENCE_BOTTLE, "&aFlask of Knowledge");

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
@@ -2105,6 +2105,18 @@ public final class SlimefunItemSetup {
         new ItemStack[] {null, null, null, null, new CustomItemStack(new ItemStack(Material.BREEZE_SPAWN_EGG), "&aBreeze"), null, null, null, null})
         .register(plugin);
 
+        new VanillaItem(itemGroups.magicalResources, SlimefunItems.WIND_CHARGE, "WIND_CHARGE", RecipeType.MOB_DROP,
+        new ItemStack[] {null, null, null, null, new CustomItemStack(new ItemStack(Material.BREEZE_SPAWN_EGG), "&aBreeze"), null, null, null, null})
+        .register(plugin);
+
+        new VanillaItem(itemGroups.magicalResources, SlimefunItems.ARMADILLO_SCUTE, "ARMADILLO_SCUTE", RecipeType.MOB_DROP,
+        new ItemStack[] {null, null, null, null, new CustomItemStack(new ItemStack(Material.ARMADILLO_SPAWN_EGG), "&aArmadillo"), null, null, null, null})
+        .register(plugin);
+
+        new VanillaItem(itemGroups.magicalResources, SlimefunItems.CREAKING_HEART, "CREAKING_HEART", RecipeType.MOB_DROP,
+        new ItemStack[] {null, null, null, null, new CustomItemStack(new ItemStack(Material.CREAKING_SPAWN_EGG), "&aCreaking"), null, null, null, null})
+        .register(plugin);
+
         new VanillaItem(itemGroups.magicalResources, new ItemStack(Material.OMINOUS_BOTTLE), "OMINOUS_BOTTLE", RecipeType.MAGIC_WORKBENCH,
         new ItemStack[] {new ItemStack(Material.COBWEB), new ItemStack(Material.BREEZE_ROD), new ItemStack(Material.COBWEB),
             new ItemStack(Material.SLIME_BALL), new ItemStack(Material.GLASS_BOTTLE), new ItemStack(Material.SLIME_BALL),


### PR DESCRIPTION
## Summary
- expose Wind Charge, Armadillo Scute and Creaking Heart as vanilla items
- document new vanilla entries for 1.21

## Testing
- `mvn -q -e test` *(hangs, terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68bd60f515a0832c969c7074d26b4553