### PR TITLE
Update MockBukkit imports for 1.21.8

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/Slimefun.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/Slimefun.java
@@ -218,7 +218,7 @@ public class Slimefun extends JavaPlugin implements SlimefunAddon {
 
         // Check that we got loaded by MockBukkit rather than Bukkit's loader
         // TODO: This is very much a hack and we can hopefully move to a more native way in the future
-        if (getClassLoader().getClass().getPackageName().startsWith("be.seeseemelk.mockbukkit")) {
+        if (getClassLoader().getClass().getPackageName().startsWith("org.mockbukkit.mockbukkit")) {
             minecraftVersion = MinecraftVersion.UNIT_TEST;
         }
     }

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/TestPluginClass.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/TestPluginClass.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 import io.github.thebusybiscuit.slimefun4.api.MinecraftVersion;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.MockBukkit;
 
 class TestPluginClass {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/api/events/TestSlimefunBlockBreakEvent.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/api/events/TestSlimefunBlockBreakEvent.java
@@ -1,9 +1,9 @@
 package io.github.thebusybiscuit.slimefun4.api.events;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
-import be.seeseemelk.mockbukkit.block.BlockMock;
-import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.block.BlockMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.BlockListener;

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/api/events/TestSlimefunBlockPlaceEvent.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/api/events/TestSlimefunBlockPlaceEvent.java
@@ -1,9 +1,9 @@
 package io.github.thebusybiscuit.slimefun4.api.events;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
-import be.seeseemelk.mockbukkit.block.BlockMock;
-import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.block.BlockMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.BlockListener;

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/api/events/TestSlimefunRegistryFinalizedEvent.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/api/events/TestSlimefunRegistryFinalizedEvent.java
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.setup.PostSetup;
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/api/events/TestTalismanActivateEvent.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/api/events/TestTalismanActivateEvent.java
@@ -1,7 +1,7 @@
 package io.github.thebusybiscuit.slimefun4.api.events;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/api/geo/TestResourceRegistration.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/api/geo/TestResourceRegistration.java
@@ -23,7 +23,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.implementation.resources.GEOResourcesSetup;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.MockBukkit;
 
 @TestMethodOrder(value = OrderAnnotation.class)
 class TestResourceRegistration {

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/api/gps/TestWaypoints.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/api/gps/TestWaypoints.java
@@ -16,8 +16,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 import io.github.thebusybiscuit.slimefun4.utils.FileUtils;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 class TestWaypoints {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/api/items/settings/TestDoubleRangeSetting.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/api/items/settings/TestDoubleRangeSetting.java
@@ -12,7 +12,7 @@ import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.MockBukkit;
 
 class TestDoubleRangeSetting {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/api/items/settings/TestEnumSetting.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/api/items/settings/TestEnumSetting.java
@@ -12,7 +12,7 @@ import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.MockBukkit;
 
 class TestEnumSetting {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/api/items/settings/TestIntRangeSetting.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/api/items/settings/TestIntRangeSetting.java
@@ -12,7 +12,7 @@ import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.MockBukkit;
 
 class TestIntRangeSetting {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/api/items/settings/TestItemSettings.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/api/items/settings/TestItemSettings.java
@@ -15,7 +15,7 @@ import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.MockBukkit;
 
 class TestItemSettings {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/api/items/settings/TestMaterialTagSetting.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/api/items/settings/TestMaterialTagSetting.java
@@ -18,7 +18,7 @@ import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.MockBukkit;
 
 class TestMaterialTagSetting {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/api/profiles/TestAsyncProfileLoadEvent.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/api/profiles/TestAsyncProfileLoadEvent.java
@@ -14,9 +14,9 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 import io.github.thebusybiscuit.slimefun4.test.mocks.MockProfile;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
-import be.seeseemelk.mockbukkit.entity.OfflinePlayerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.OfflinePlayerMock;
 
 class TestAsyncProfileLoadEvent {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/api/profiles/TestGuideHistory.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/api/profiles/TestGuideHistory.java
@@ -18,8 +18,8 @@ import io.github.thebusybiscuit.slimefun4.core.guide.GuideHistory;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 class TestGuideHistory {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/api/profiles/TestPlayerBackpacks.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/api/profiles/TestPlayerBackpacks.java
@@ -14,8 +14,8 @@ import io.github.thebusybiscuit.slimefun4.api.player.PlayerProfile;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 class TestPlayerBackpacks {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/api/profiles/TestPlayerProfile.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/api/profiles/TestPlayerProfile.java
@@ -16,9 +16,9 @@ import io.github.thebusybiscuit.slimefun4.api.player.PlayerProfile;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
-import be.seeseemelk.mockbukkit.entity.OfflinePlayerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.OfflinePlayerMock;
 
 class TestPlayerProfile {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/core/commands/TestBackpackCommand.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/core/commands/TestBackpackCommand.java
@@ -21,8 +21,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 class TestBackpackCommand {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/core/commands/TestChargeCommand.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/core/commands/TestChargeCommand.java
@@ -18,8 +18,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 import io.github.thebusybiscuit.slimefun4.utils.LoreBuilder;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 class TestChargeCommand {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/core/commands/TestDebugFishCommand.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/core/commands/TestDebugFishCommand.java
@@ -12,8 +12,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 class TestDebugFishCommand {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/core/commands/TestGuideCommand.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/core/commands/TestGuideCommand.java
@@ -14,8 +14,8 @@ import io.github.thebusybiscuit.slimefun4.core.guide.SlimefunGuideMode;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 class TestGuideCommand {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/core/commands/TestResearchCommand.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/core/commands/TestResearchCommand.java
@@ -13,8 +13,8 @@ import io.github.thebusybiscuit.slimefun4.api.researches.Research;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 class TestResearchCommand {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/core/debug/TestDebugLogging.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/core/debug/TestDebugLogging.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.MockBukkit;
 
 class TestDebugLogging {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/core/guide/TestGuideOpening.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/core/guide/TestGuideOpening.java
@@ -25,8 +25,8 @@ import io.github.thebusybiscuit.slimefun4.api.player.PlayerProfile;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 class TestGuideOpening {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/TestMultiBlocks.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/TestMultiBlocks.java
@@ -13,7 +13,7 @@ import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.MockBukkit;
 
 class TestMultiBlocks {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/core/networks/TestNetworkManager.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/core/networks/TestNetworkManager.java
@@ -21,8 +21,8 @@ import io.github.thebusybiscuit.slimefun4.api.network.NetworkComponent;
 import io.github.thebusybiscuit.slimefun4.core.networks.cargo.CargoNet;
 import io.github.thebusybiscuit.slimefun4.test.mocks.MockNetwork;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 class TestNetworkManager {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/core/researching/TestProfileResearches.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/core/researching/TestProfileResearches.java
@@ -15,8 +15,8 @@ import io.github.thebusybiscuit.slimefun4.api.researches.Research;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 class TestProfileResearches {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/core/researching/TestResearchUnlocking.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/core/researching/TestResearchUnlocking.java
@@ -19,8 +19,8 @@ import io.github.thebusybiscuit.slimefun4.api.player.PlayerProfile;
 import io.github.thebusybiscuit.slimefun4.api.researches.Research;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 class TestResearchUnlocking {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/core/researching/TestResearches.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/core/researching/TestResearches.java
@@ -22,8 +22,8 @@ import io.github.thebusybiscuit.slimefun4.core.guide.SlimefunGuideImplementation
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 class TestResearches {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/core/services/TestBlockDataService.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/core/services/TestBlockDataService.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.MockBukkit;
 
 class TestBlockDataService {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/core/services/TestCustomTextureService.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/core/services/TestCustomTextureService.java
@@ -15,7 +15,7 @@ import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.MockBukkit;
 
 class TestCustomTextureService {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/core/services/TestItemDataService.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/core/services/TestItemDataService.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.MockBukkit;
 
 class TestItemDataService {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/core/services/TestPermissionsService.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/core/services/TestPermissionsService.java
@@ -20,8 +20,8 @@ import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 class TestPermissionsService {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/core/services/TestRecipeService.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/core/services/TestRecipeService.java
@@ -21,8 +21,8 @@ import org.junit.jupiter.api.Test;
 import io.github.bakedlibs.dough.recipes.RecipeSnapshot;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 class TestRecipeService {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/core/services/TestUpdaterService.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/core/services/TestUpdaterService.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import io.github.thebusybiscuit.slimefun4.api.SlimefunBranch;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.MockBukkit;
 
 class TestUpdaterService {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/core/services/localization/AbstractLocaleRegexChecker.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/core/services/localization/AbstractLocaleRegexChecker.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.provider.Arguments;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.MockBukkit;
 
 class AbstractLocaleRegexChecker {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/TestDamageableItem.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/TestDamageableItem.java
@@ -21,8 +21,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 import io.github.thebusybiscuit.slimefun4.test.mocks.MockDamageable;
 import io.github.thebusybiscuit.slimefun4.utils.compatibility.VersionedEnchantment;
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 class TestDamageableItem {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/TestRadioactiveItem.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/TestRadioactiveItem.java
@@ -16,7 +16,7 @@ import io.github.thebusybiscuit.slimefun4.core.attributes.Radioactivity;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.MockBukkit;
 
 class TestRadioactiveItem {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/TestSlimefunItem.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/TestSlimefunItem.java
@@ -21,7 +21,7 @@ import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.MockBukkit;
 
 class TestSlimefunItem {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/TestAbstractRecipe.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/TestAbstractRecipe.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.MockBukkit;
 
 class TestAbstractRecipe {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/TestAutoCrafter.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/autocrafters/TestAutoCrafter.java
@@ -21,9 +21,9 @@ import io.github.thebusybiscuit.slimefun4.core.networks.energy.EnergyNetComponen
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.inventory.ChestInventoryMock;
-import be.seeseemelk.mockbukkit.inventory.InventoryMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.inventory.ChestInventoryMock;
+import org.mockbukkit.mockbukkit.inventory.InventoryMock;
 
 class TestAutoCrafter {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/backpacks/TestEnderBackpack.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/backpacks/TestEnderBackpack.java
@@ -15,8 +15,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 import io.github.thebusybiscuit.slimefun4.test.presets.SlimefunItemTest;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 class TestEnderBackpack implements SlimefunItemTest<EnderBackpack> {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/food/TestDietCookie.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/food/TestDietCookie.java
@@ -16,9 +16,9 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 import io.github.thebusybiscuit.slimefun4.test.presets.SlimefunItemTest;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
-import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
 
 class TestDietCookie implements SlimefunItemTest<DietCookie> {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/food/TestMeatJerky.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/food/TestMeatJerky.java
@@ -14,9 +14,9 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 import io.github.thebusybiscuit.slimefun4.test.presets.SlimefunItemTest;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
-import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
 
 class TestMeatJerky implements SlimefunItemTest<MeatJerky> {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/food/TestMonsterJerky.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/food/TestMonsterJerky.java
@@ -15,9 +15,9 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 import io.github.thebusybiscuit.slimefun4.test.presets.SlimefunItemTest;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
-import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
 
 class TestMonsterJerky implements SlimefunItemTest<MonsterJerky> {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/TestClimbingPick.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/TestClimbingPick.java
@@ -28,10 +28,10 @@ import io.github.thebusybiscuit.slimefun4.test.presets.SlimefunItemTest;
 import io.github.thebusybiscuit.slimefun4.utils.compatibility.VersionedEnchantment;
 import io.github.thebusybiscuit.slimefun4.utils.tags.SlimefunTag;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
-import be.seeseemelk.mockbukkit.block.BlockMock;
-import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.block.BlockMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
 
 class TestClimbingPick implements SlimefunItemTest<ClimbingPick> {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/TestPortableDustbin.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/TestPortableDustbin.java
@@ -16,8 +16,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 import io.github.thebusybiscuit.slimefun4.test.presets.SlimefunItemTest;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 class TestPortableDustbin implements SlimefunItemTest<PortableDustbin> {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/TestTapeMeasure.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/TestTapeMeasure.java
@@ -21,11 +21,11 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 import io.github.thebusybiscuit.slimefun4.test.presets.SlimefunItemTest;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
-import be.seeseemelk.mockbukkit.WorldMock;
-import be.seeseemelk.mockbukkit.block.BlockMock;
-import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.world.WorldMock;
+import org.mockbukkit.mockbukkit.block.BlockMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
 
 class TestTapeMeasure implements SlimefunItemTest<TapeMeasure> {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestAnvilListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestAnvilListener.java
@@ -23,8 +23,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.VanillaItem;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.crafting.AnvilListener;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 class TestAnvilListener {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestBackpackListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestBackpackListener.java
@@ -38,9 +38,9 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.backpacks.Slimefu
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 import io.github.thebusybiscuit.slimefun4.utils.tags.SlimefunTag;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
-import be.seeseemelk.mockbukkit.entity.ItemEntityMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.ItemEntityMock;
 
 class TestBackpackListener {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestBeeListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestBeeListener.java
@@ -20,8 +20,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.entity.BeeListener;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 class TestBeeListener {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestBrewingStandListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestBrewingStandListener.java
@@ -25,8 +25,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.VanillaItem;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.crafting.BrewingStandListener;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 class TestBrewingStandListener {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestCargoNodeListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestCargoNodeListener.java
@@ -24,8 +24,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.cargo.CargoInputN
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 import io.github.thebusybiscuit.slimefun4.test.providers.SlimefunItemsSource;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 class TestCargoNodeListener {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestCartographyTableListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestCartographyTableListener.java
@@ -23,8 +23,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.VanillaItem;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.crafting.CartographyTableListener;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 class TestCartographyTableListener {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestCauldronListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestCauldronListener.java
@@ -22,9 +22,9 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.VanillaItem;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.crafting.CauldronListener;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
-import be.seeseemelk.mockbukkit.block.BlockMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.block.BlockMock;
 
 class TestCauldronListener {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestCoolerListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestCoolerListener.java
@@ -25,8 +25,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.items.backpacks.Cooler;
 import io.github.thebusybiscuit.slimefun4.implementation.items.food.Juice;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 class TestCoolerListener {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestCraftingTableListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestCraftingTableListener.java
@@ -28,8 +28,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.VanillaItem;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.crafting.CraftingTableListener;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 class TestCraftingTableListener {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestDeathpointListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestDeathpointListener.java
@@ -12,8 +12,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 class TestDeathpointListener {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestFireworksListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestFireworksListener.java
@@ -15,8 +15,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.entity.FireworksListener;
 import io.github.thebusybiscuit.slimefun4.utils.FireworkUtils;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 class TestFireworksListener {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestGrindstoneListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestGrindstoneListener.java
@@ -27,8 +27,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.VanillaItem;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.crafting.GrindstoneListener;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 class TestGrindstoneListener {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestIronGolemListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestIronGolemListener.java
@@ -21,8 +21,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.VanillaItem;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.entity.IronGolemListener;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 class TestIronGolemListener {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestItemPickupListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestItemPickupListener.java
@@ -21,10 +21,10 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.items.altar.AncientPedestal;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
-import be.seeseemelk.mockbukkit.entity.ItemEntityMock;
-import be.seeseemelk.mockbukkit.inventory.HopperInventoryMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.ItemEntityMock;
+import org.mockbukkit.mockbukkit.inventory.HopperInventoryMock;
 
 class TestItemPickupListener {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestMultiblockListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestMultiblockListener.java
@@ -22,8 +22,8 @@ import io.github.thebusybiscuit.slimefun4.core.multiblocks.MultiBlock;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 class TestMultiblockListener {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestNetworkListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestNetworkListener.java
@@ -18,8 +18,8 @@ import io.github.thebusybiscuit.slimefun4.api.network.Network;
 import io.github.thebusybiscuit.slimefun4.core.networks.NetworkManager;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 class TestNetworkListener {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestPiglinListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestPiglinListener.java
@@ -25,9 +25,9 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.entity.PiglinListener;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
-import be.seeseemelk.mockbukkit.entity.ItemEntityMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.ItemEntityMock;
 
 class TestPiglinListener {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestPlayerProfileListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestPlayerProfileListener.java
@@ -13,8 +13,8 @@ import io.github.thebusybiscuit.slimefun4.api.player.PlayerProfile;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 class TestPlayerProfileListener {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestSlimefunGuideListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestSlimefunGuideListener.java
@@ -17,9 +17,9 @@ import io.github.thebusybiscuit.slimefun4.core.guide.SlimefunGuide;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
-import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
 
 class TestSlimefunGuideListener {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestSlimefunItemInteractListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestSlimefunItemInteractListener.java
@@ -30,9 +30,9 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.magical.staves.Wi
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenuPreset;
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
-import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
 
 class TestSlimefunItemInteractListener {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestSmithingTableListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestSmithingTableListener.java
@@ -1,7 +1,7 @@
 package io.github.thebusybiscuit.slimefun4.implementation.listeners;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 import org.apache.commons.lang3.mutable.MutableObject;
 import org.bukkit.Material;

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestSoulboundListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestSoulboundListener.java
@@ -18,9 +18,9 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.magical.Soulbound
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
-import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
 
 class TestSoulboundListener {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestVillagerTradingListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TestVillagerTradingListener.java
@@ -27,8 +27,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.VanillaItem;
 import io.github.thebusybiscuit.slimefun4.implementation.items.misc.SyntheticEmerald;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 class TestVillagerTradingListener {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/registration/TestItemGroups.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/registration/TestItemGroups.java
@@ -27,8 +27,8 @@ import io.github.thebusybiscuit.slimefun4.core.guide.SlimefunGuideMode;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 class TestItemGroups {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/registration/TestItemHandlers.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/registration/TestItemHandlers.java
@@ -19,7 +19,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 import io.github.thebusybiscuit.slimefun4.test.mocks.MockItemHandler;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.MockBukkit;
 
 class TestItemHandlers {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/registration/TestRechargeableItems.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/registration/TestRechargeableItems.java
@@ -18,7 +18,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 import io.github.thebusybiscuit.slimefun4.utils.LoreBuilder;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.MockBukkit;
 
 class TestRechargeableItems {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/registration/TestRegistration.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/registration/TestRegistration.java
@@ -32,7 +32,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.setup.PostSetup;
 import io.github.thebusybiscuit.slimefun4.implementation.setup.ResearchSetup;
 import io.github.thebusybiscuit.slimefun4.implementation.setup.SlimefunItemSetup;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.MockBukkit;
 
 @TestMethodOrder(value = OrderAnnotation.class)
 class TestRegistration {

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/registration/TestSlimefunItemRegistration.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/registration/TestSlimefunItemRegistration.java
@@ -17,7 +17,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.items.VanillaItem;
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.MockBukkit;
 
 class TestSlimefunItemRegistration {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TestArmorTask.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TestArmorTask.java
@@ -28,8 +28,8 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.armor.SlimefunArm
 import io.github.thebusybiscuit.slimefun4.test.TestUtilities;
 import io.github.thebusybiscuit.slimefun4.test.mocks.MockHazmatSuit;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 
 class TestArmorTask {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/storage/backend/TestLegacyBackend.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/storage/backend/TestLegacyBackend.java
@@ -22,8 +22,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
 import io.github.thebusybiscuit.slimefun4.api.gps.Waypoint;
 import io.github.thebusybiscuit.slimefun4.api.player.PlayerProfile;
 import io.github.thebusybiscuit.slimefun4.api.researches.Research;

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/test/TestUtilities.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/test/TestUtilities.java
@@ -26,8 +26,8 @@ import org.bukkit.plugin.Plugin;
 import org.junit.jupiter.api.Assertions;
 import org.mockito.Mockito;
 
-import be.seeseemelk.mockbukkit.ServerMock;
-import be.seeseemelk.mockbukkit.block.BlockMock;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.block.BlockMock;
 import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.api.events.SlimefunBlockPlaceEvent;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/test/presets/SlimefunItemTest.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/test/presets/SlimefunItemTest.java
@@ -16,7 +16,7 @@ import io.github.thebusybiscuit.slimefun4.core.handlers.ItemConsumptionHandler;
 import io.github.thebusybiscuit.slimefun4.core.handlers.ItemUseHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 
-import be.seeseemelk.mockbukkit.block.BlockMock;
+import org.mockbukkit.mockbukkit.block.BlockMock;
 
 /**
  * This is a convenient interface for us to use in unit test classes

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/utils/TestChargeUtils.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/utils/TestChargeUtils.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 import io.github.bakedlibs.dough.data.persistent.PersistentDataAPI;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.MockBukkit;
 
 class TestChargeUtils {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/utils/TestFireworkUtils.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/utils/TestFireworkUtils.java
@@ -17,8 +17,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.WorldMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.world.WorldMock;
 
 class TestFireworkUtils {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/utils/TestInfiniteBlockGenerators.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/utils/TestInfiniteBlockGenerators.java
@@ -20,9 +20,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
-import be.seeseemelk.mockbukkit.ServerMock;
-import be.seeseemelk.mockbukkit.WorldMock;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.world.WorldMock;
 
 class TestInfiniteBlockGenerators {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/utils/TestItemStackWrapper.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/utils/TestItemStackWrapper.java
@@ -17,7 +17,7 @@ import io.github.bakedlibs.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackWrapper;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.MockBukkit;
 
 class TestItemStackWrapper {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/utils/TestLoreComparison.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/utils/TestLoreComparison.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.MockBukkit;
 
 class TestLoreComparison {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/utils/TestSoulboundItem.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/utils/TestSoulboundItem.java
@@ -17,7 +17,7 @@ import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.core.attributes.Soulbound;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.MockBukkit;
 
 class TestSoulboundItem {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/utils/biomes/TestBiomeMap.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/utils/biomes/TestBiomeMap.java
@@ -16,7 +16,7 @@ import com.google.gson.JsonElement;
 import io.github.thebusybiscuit.slimefun4.api.exceptions.BiomeMapException;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.MockBukkit;
 
 class TestBiomeMap {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/utils/biomes/TestBiomeMapCompatibility.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/utils/biomes/TestBiomeMapCompatibility.java
@@ -29,7 +29,7 @@ import io.github.thebusybiscuit.slimefun4.api.MinecraftVersion;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.utils.JsonUtils;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.MockBukkit;
 
 /**
  * This test checks if biome maps work across multiple versions of Minecraft.

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/utils/biomes/TestBiomeMapParser.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/utils/biomes/TestBiomeMapParser.java
@@ -17,7 +17,7 @@ import com.google.gson.JsonElement;
 import io.github.thebusybiscuit.slimefun4.api.exceptions.BiomeMapException;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.MockBukkit;
 
 class TestBiomeMapParser {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/utils/tags/TestSlimefunTags.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/utils/tags/TestSlimefunTags.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 import io.github.thebusybiscuit.slimefun4.api.exceptions.TagMisconfigurationException;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.MockBukkit;
 
 class TestSlimefunTags {
 

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/utils/tags/TestTagParser.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/utils/tags/TestTagParser.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 import io.github.thebusybiscuit.slimefun4.api.exceptions.TagMisconfigurationException;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 
-import be.seeseemelk.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.MockBukkit;
 
 class TestTagParser {
 


### PR DESCRIPTION
## Summary
- Migrate all MockBukkit imports to the new `org.mockbukkit.mockbukkit` package structure
- Adjust MockBukkit detection for unit tests to use the updated package name

## Testing
- `mvn package` *(fails: java.lang.NoSuchMethodException: org.bukkit.entity.Firework.<init>(org.mockbukkit.mockbukkit.ServerMock,java.util.UUID))*
- `mvn -DskipTests package`


------
https://chatgpt.com/codex/tasks/task_e_68bd65e33a98832cb94675f5b13f995a