### PR TITLE
Centralize 1.21 material references

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunItems.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunItems.java
@@ -23,6 +23,7 @@ import io.github.thebusybiscuit.slimefun4.utils.ChatUtils;
 import io.github.thebusybiscuit.slimefun4.utils.HeadTexture;
 import io.github.thebusybiscuit.slimefun4.utils.LoreBuilder;
 import io.github.thebusybiscuit.slimefun4.utils.compatibility.VersionedEnchantment;
+import io.github.thebusybiscuit.slimefun4.utils.compatibility.VersionedMaterial;
 import io.github.thebusybiscuit.slimefun4.utils.itemstack.ColoredFireworkStar;
 
 /**
@@ -65,27 +66,32 @@ public final class SlimefunItems {
     public static final SlimefunItemStack MAGICAL_ZOMBIE_PILLS = new SlimefunItemStack("MAGICAL_ZOMBIE_PILLS", Material.NETHER_WART, "&6Magical Zombie Pills", "", "&eRight Click &7a Zombified Villager", "&eor &7a Zombified Piglin to", "&7instantly cure it from its curse");
     public static final SlimefunItemStack WOLF_ARMOR = new SlimefunItemStack(
         "WOLF_ARMOR",
-        Material.matchMaterial("WOLF_ARMOR") == null ? Material.LEATHER_CHESTPLATE : Material.matchMaterial("WOLF_ARMOR"),
+        VersionedMaterial.WOLF_ARMOR == null ? Material.LEATHER_CHESTPLATE : VersionedMaterial.WOLF_ARMOR,
         "&6Wolf Armor");
     public static final SlimefunItemStack BREEZE_ROD = new SlimefunItemStack(
         "BREEZE_ROD",
-        Material.matchMaterial("BREEZE_ROD") == null ? Material.BLAZE_ROD : Material.matchMaterial("BREEZE_ROD"),
+        VersionedMaterial.BREEZE_ROD == null ? Material.BLAZE_ROD : VersionedMaterial.BREEZE_ROD,
         "&bBreeze Rod");
+    public static final SlimefunItemStack WIND_CHARGE = new SlimefunItemStack(
+        "WIND_CHARGE",
+        VersionedMaterial.WIND_CHARGE == null ? Material.SNOWBALL : VersionedMaterial.WIND_CHARGE,
+        "&bWind Charge");
+    public static final SlimefunItemStack ARMADILLO_SCUTE = new SlimefunItemStack(
+        "ARMADILLO_SCUTE",
+        VersionedMaterial.ARMADILLO_SCUTE == null ? Material.TURTLE_SCUTE : VersionedMaterial.ARMADILLO_SCUTE,
+        "&6Armadillo Scute");
+    public static final SlimefunItemStack CREAKING_HEART = new SlimefunItemStack(
+        "CREAKING_HEART",
+        VersionedMaterial.CREAKING_HEART == null ? Material.ROTTEN_FLESH : VersionedMaterial.CREAKING_HEART,
+        "&cCreaking Heart");
     public static final SlimefunItemStack HEAVY_CORE = new SlimefunItemStack(
         "HEAVY_CORE",
-        Material.matchMaterial("HEAVY_CORE") == null ? Material.IRON_BLOCK : Material.matchMaterial("HEAVY_CORE"),
+        VersionedMaterial.HEAVY_CORE == null ? Material.IRON_BLOCK : VersionedMaterial.HEAVY_CORE,
         "&6Heavy Core");
     public static final SlimefunItemStack MACE = new SlimefunItemStack(
         "MACE",
-        Material.matchMaterial("MACE") == null ? Material.DIAMOND_SWORD : Material.matchMaterial("MACE"),
+        VersionedMaterial.MACE == null ? Material.DIAMOND_SWORD : VersionedMaterial.MACE,
         "&6Mace");
-    public static final SlimefunItemStack WOLF_ARMOR = new SlimefunItemStack("WOLF_ARMOR", Material.WOLF_ARMOR, "&6Wolf Armor");
-    public static final SlimefunItemStack BREEZE_ROD = new SlimefunItemStack("BREEZE_ROD", Material.BREEZE_ROD, "&bBreeze Rod");
-    public static final SlimefunItemStack WIND_CHARGE = new SlimefunItemStack("WIND_CHARGE", Material.WIND_CHARGE, "&bWind Charge");
-    public static final SlimefunItemStack ARMADILLO_SCUTE = new SlimefunItemStack("ARMADILLO_SCUTE", Material.ARMADILLO_SCUTE, "&6Armadillo Scute");
-    public static final SlimefunItemStack CREAKING_HEART = new SlimefunItemStack("CREAKING_HEART", Material.CREAKING_HEART, "&cCreaking Heart");
-    public static final SlimefunItemStack HEAVY_CORE = new SlimefunItemStack("HEAVY_CORE", Material.HEAVY_CORE, "&6Heavy Core");
-    public static final SlimefunItemStack MACE = new SlimefunItemStack("MACE", Material.MACE, "&6Mace");
     public static final SlimefunItemStack FLASK_OF_KNOWLEDGE = new SlimefunItemStack("FLASK_OF_KNOWLEDGE", Material.GLASS_BOTTLE, "&cFlask of Knowledge", "", "&fAllows you to store some of", "&fyour Experience in a Bottle", "&7Cost: &a1 Level");
     public static final SlimefunItemStack FILLED_FLASK_OF_KNOWLEDGE = new SlimefunItemStack("FILLED_FLASK_OF_KNOWLEDGE", Material.EXPERIENCE_BOTTLE, "&aFlask of Knowledge");
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/AutoBrewer.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/AutoBrewer.java
@@ -20,6 +20,7 @@ import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.core.attributes.NotHopperable;
 import io.github.thebusybiscuit.slimefun4.utils.compatibility.VersionedPotionType;
+import io.github.thebusybiscuit.slimefun4.utils.compatibility.VersionedMaterial;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.AContainer;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.MachineRecipe;
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
@@ -52,9 +53,8 @@ public class AutoBrewer extends AContainer implements NotHopperable {
         potionRecipes.put(Material.COBWEB, VersionedPotionType.WEAVING);
         potionRecipes.put(Material.STONE, VersionedPotionType.INFESTED);
 
-        Material breezeRod = Material.matchMaterial("BREEZE_ROD");
-        if (breezeRod != null) {
-            potionRecipes.put(breezeRod, VersionedPotionType.WIND_CHARGED);
+        if (VersionedMaterial.BREEZE_ROD != null) {
+            potionRecipes.put(VersionedMaterial.BREEZE_ROD, VersionedPotionType.WIND_CHARGED);
         }
 
         fermentations.put(VersionedPotionType.SWIFTNESS, PotionType.SLOWNESS);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/ProduceCollector.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/entities/ProduceCollector.java
@@ -34,6 +34,7 @@ import io.github.thebusybiscuit.slimefun4.core.attributes.RecipeDisplayItem;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 import io.github.thebusybiscuit.slimefun4.utils.compatibility.VersionedEntityType;
+import io.github.thebusybiscuit.slimefun4.utils.compatibility.VersionedMaterial;
 
 import me.mrCookieSlime.CSCoreLibPlugin.Configuration.Config;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.AContainer;
@@ -85,9 +86,8 @@ public class ProduceCollector extends AContainer implements RecipeDisplayItem {
 
         // Armadillo Scutes from Armadillos
         if (Slimefun.getMinecraftVersion().isAtLeast(MinecraftVersion.MINECRAFT_1_21)) {
-            Material scute = Material.matchMaterial("ARMADILLO_SCUTE");
-            if (scute != null) {
-                addProduce(new AnimalProduce(new ItemStack(Material.BRUSH), new ItemStack(scute), n -> {
+            if (VersionedMaterial.ARMADILLO_SCUTE != null) {
+                addProduce(new AnimalProduce(new ItemStack(Material.BRUSH), new ItemStack(VersionedMaterial.ARMADILLO_SCUTE), n -> {
                     if (n.getType() == VersionedEntityType.ARMADILLO && n instanceof Ageable ageable) {
                         return ageable.isAdult();
                     } else {
@@ -143,10 +143,9 @@ public class ProduceCollector extends AContainer implements RecipeDisplayItem {
         displayRecipes.add(new ItemStack(Material.MUSHROOM_STEW));
 
         if (Slimefun.getMinecraftVersion().isAtLeast(MinecraftVersion.MINECRAFT_1_21)) {
-            Material scute = Material.matchMaterial("ARMADILLO_SCUTE");
-            if (scute != null) {
+            if (VersionedMaterial.ARMADILLO_SCUTE != null) {
                 displayRecipes.add(new CustomItemStack(Material.BRUSH, null, "&fRequires &bArmadillo &fnearby"));
-                displayRecipes.add(new ItemStack(scute));
+                displayRecipes.add(new ItemStack(VersionedMaterial.ARMADILLO_SCUTE));
             }
         }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/ButcherAndroidListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/ButcherAndroidListener.java
@@ -24,6 +24,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.androids.AndroidI
 import io.github.thebusybiscuit.slimefun4.implementation.items.androids.ButcherAndroid;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 import io.github.thebusybiscuit.slimefun4.utils.compatibility.VersionedEntityType;
+import io.github.thebusybiscuit.slimefun4.utils.compatibility.VersionedMaterial;
 
 /**
  * This {@link Listener} handles the collection of drops from an {@link Entity} that was
@@ -99,25 +100,21 @@ public class ButcherAndroidListener implements Listener {
             drops.add(new ItemStack(Material.RED_MUSHROOM, 1 + random.nextInt(2)));
         }
 
-        Material scute = Material.matchMaterial("ARMADILLO_SCUTE");
-        if (entityType == VersionedEntityType.ARMADILLO && scute != null) {
-            drops.add(new ItemStack(scute, 1 + random.nextInt(2)));
+        if (entityType == VersionedEntityType.ARMADILLO && VersionedMaterial.ARMADILLO_SCUTE != null) {
+            drops.add(new ItemStack(VersionedMaterial.ARMADILLO_SCUTE, 1 + random.nextInt(2)));
         }
 
-        Material breezeRod = Material.matchMaterial("BREEZE_ROD");
-        Material windCharge = Material.matchMaterial("WIND_CHARGE");
         if (entityType == VersionedEntityType.BREEZE) {
-            if (breezeRod != null) {
-                drops.add(new ItemStack(breezeRod));
+            if (VersionedMaterial.BREEZE_ROD != null) {
+                drops.add(new ItemStack(VersionedMaterial.BREEZE_ROD));
             }
-            if (windCharge != null && random.nextInt(3) == 0) {
-                drops.add(new ItemStack(windCharge));
+            if (VersionedMaterial.WIND_CHARGE != null && random.nextInt(3) == 0) {
+                drops.add(new ItemStack(VersionedMaterial.WIND_CHARGE));
             }
         }
 
-        Material creakingHeart = Material.matchMaterial("CREAKING_HEART");
-        if (entityType == VersionedEntityType.CREAKING && creakingHeart != null) {
-            drops.add(new ItemStack(creakingHeart));
+        if (entityType == VersionedEntityType.CREAKING && VersionedMaterial.CREAKING_HEART != null) {
+            drops.add(new ItemStack(VersionedMaterial.CREAKING_HEART));
         }
     }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
@@ -218,6 +218,7 @@ import io.github.thebusybiscuit.slimefun4.utils.ColoredMaterial;
 import io.github.thebusybiscuit.slimefun4.utils.HeadTexture;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 import io.github.thebusybiscuit.slimefun4.utils.compatibility.VersionedPotionEffectType;
+import io.github.thebusybiscuit.slimefun4.utils.compatibility.VersionedMaterial;
 
 /**
  * This class holds the recipes of all items.
@@ -2090,18 +2091,18 @@ public final class SlimefunItemSetup {
         .register(plugin);
 
         if (Slimefun.getMinecraftVersion().isAtLeast(MinecraftVersion.MINECRAFT_1_21)) {
-            Material crafter = Material.matchMaterial("CRAFTER");
-            Material copperBulb = Material.matchMaterial("COPPER_BULB");
-            Material breezeSpawnEgg = Material.matchMaterial("BREEZE_SPAWN_EGG");
-            Material breezeRod = Material.matchMaterial("BREEZE_ROD");
-            Material ominousBottle = Material.matchMaterial("OMINOUS_BOTTLE");
-            Material trialKey = Material.matchMaterial("TRIAL_KEY");
-            Material vault = Material.matchMaterial("VAULT");
-            Material trialSpawner = Material.matchMaterial("TRIAL_SPAWNER");
-            Material heavyCore = Material.matchMaterial("HEAVY_CORE");
-            Material mace = Material.matchMaterial("MACE");
-            Material wolfArmor = Material.matchMaterial("WOLF_ARMOR");
-            Material armadilloScute = Material.matchMaterial("ARMADILLO_SCUTE");
+            Material crafter = VersionedMaterial.CRAFTER;
+            Material copperBulb = VersionedMaterial.COPPER_BULB;
+            Material breezeSpawnEgg = VersionedMaterial.BREEZE_SPAWN_EGG;
+            Material breezeRod = VersionedMaterial.BREEZE_ROD;
+            Material ominousBottle = VersionedMaterial.OMINOUS_BOTTLE;
+            Material trialKey = VersionedMaterial.TRIAL_KEY;
+            Material vault = VersionedMaterial.VAULT;
+            Material trialSpawner = VersionedMaterial.TRIAL_SPAWNER;
+            Material heavyCore = VersionedMaterial.HEAVY_CORE;
+            Material mace = VersionedMaterial.MACE;
+            Material wolfArmor = VersionedMaterial.WOLF_ARMOR;
+            Material armadilloScute = VersionedMaterial.ARMADILLO_SCUTE;
 
             new VanillaItem(itemGroups.basicMachines, new ItemStack(crafter), "CRAFTER", RecipeType.ENHANCED_CRAFTING_TABLE,
                 new ItemStack[] {new ItemStack(Material.IRON_INGOT), new ItemStack(Material.IRON_INGOT), new ItemStack(Material.REDSTONE),
@@ -2771,27 +2772,26 @@ public final class SlimefunItemSetup {
                 new SlimefunItemStack(SlimefunItems.RAINBOW_LEATHER, 4))
                 .register(plugin);
 
-        Material crafterMaterial = Material.matchMaterial("CRAFTER");
-        if (crafterMaterial != null) {
+        if (VersionedMaterial.CRAFTER != null) {
             new UnplaceableBlock(itemGroups.cargo, SlimefunItems.CRAFTING_MOTOR, RecipeType.ENHANCED_CRAFTING_TABLE,
-                new ItemStack[] {new ItemStack(crafterMaterial), SlimefunItems.BLISTERING_INGOT_3, new ItemStack(crafterMaterial), SlimefunItems.REDSTONE_ALLOY, SlimefunItems.CARGO_MOTOR, SlimefunItems.REDSTONE_ALLOY, new ItemStack(crafterMaterial), SlimefunItems.BLISTERING_INGOT_3, new ItemStack(crafterMaterial)},
+                new ItemStack[] {new ItemStack(VersionedMaterial.CRAFTER), SlimefunItems.BLISTERING_INGOT_3, new ItemStack(VersionedMaterial.CRAFTER), SlimefunItems.REDSTONE_ALLOY, SlimefunItems.CARGO_MOTOR, SlimefunItems.REDSTONE_ALLOY, new ItemStack(VersionedMaterial.CRAFTER), SlimefunItems.BLISTERING_INGOT_3, new ItemStack(VersionedMaterial.CRAFTER)},
                 new SlimefunItemStack(SlimefunItems.CRAFTING_MOTOR, 2))
                 .register(plugin);
 
             new VanillaAutoCrafter(itemGroups.cargo, SlimefunItems.VANILLA_AUTO_CRAFTER, RecipeType.ENHANCED_CRAFTING_TABLE,
-                new ItemStack[] {null, SlimefunItems.CARGO_MOTOR, null, new ItemStack(crafterMaterial), SlimefunItems.CRAFTING_MOTOR, new ItemStack(crafterMaterial), null, SlimefunItems.ELECTRIC_MOTOR, null})
+                new ItemStack[] {null, SlimefunItems.CARGO_MOTOR, null, new ItemStack(VersionedMaterial.CRAFTER), SlimefunItems.CRAFTING_MOTOR, new ItemStack(VersionedMaterial.CRAFTER), null, SlimefunItems.ELECTRIC_MOTOR, null})
                 .setCapacity(256)
                 .setEnergyConsumption(16)
                 .register(plugin);
 
             new EnhancedAutoCrafter(itemGroups.cargo, SlimefunItems.ENHANCED_AUTO_CRAFTER, RecipeType.ENHANCED_CRAFTING_TABLE,
-                new ItemStack[] {null, SlimefunItems.CRAFTING_MOTOR, null, new ItemStack(crafterMaterial), new ItemStack(Material.DISPENSER), new ItemStack(crafterMaterial), null, SlimefunItems.CARGO_MOTOR, null})
+                new ItemStack[] {null, SlimefunItems.CRAFTING_MOTOR, null, new ItemStack(VersionedMaterial.CRAFTER), new ItemStack(Material.DISPENSER), new ItemStack(VersionedMaterial.CRAFTER), null, SlimefunItems.CARGO_MOTOR, null})
                 .setCapacity(256)
                 .setEnergyConsumption(16)
                 .register(plugin);
 
             new ArmorAutoCrafter(itemGroups.cargo, SlimefunItems.ARMOR_AUTO_CRAFTER, RecipeType.ENHANCED_CRAFTING_TABLE,
-                new ItemStack[] {null, SlimefunItems.CRAFTING_MOTOR, null, new ItemStack(Material.DISPENSER), new ItemStack(Material.ANVIL), new ItemStack(Material.DISPENSER), new ItemStack(crafterMaterial), SlimefunItems.ELECTRIC_MOTOR, new ItemStack(crafterMaterial)})
+                new ItemStack[] {null, SlimefunItems.CRAFTING_MOTOR, null, new ItemStack(Material.DISPENSER), new ItemStack(Material.ANVIL), new ItemStack(Material.DISPENSER), new ItemStack(VersionedMaterial.CRAFTER), SlimefunItems.ELECTRIC_MOTOR, new ItemStack(VersionedMaterial.CRAFTER)})
                 .setCapacity(256)
                 .setEnergyConsumption(32)
                 .register(plugin);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/compatibility/VersionedMaterial.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/compatibility/VersionedMaterial.java
@@ -1,0 +1,42 @@
+package io.github.thebusybiscuit.slimefun4.utils.compatibility;
+
+import org.bukkit.Material;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Utility class providing {@link Material} constants that may not exist on
+ * older Minecraft versions. Each field is initialised using
+ * {@link Material#matchMaterial(String)} to avoid {@link NoSuchFieldError}
+ * when running on legacy servers.
+ *
+ * <p>This class centralises lookups for new 1.21 materials so that other
+ * classes can reference them safely.</p>
+ */
+public final class VersionedMaterial {
+
+    private VersionedMaterial() {
+    }
+
+    // 1.21 items
+    public static final Material ARMADILLO_SCUTE = get("ARMADILLO_SCUTE");
+    public static final Material BREEZE_ROD = get("BREEZE_ROD");
+    public static final Material WIND_CHARGE = get("WIND_CHARGE");
+    public static final Material CREAKING_HEART = get("CREAKING_HEART");
+    public static final Material OMINOUS_BOTTLE = get("OMINOUS_BOTTLE");
+    public static final Material TRIAL_KEY = get("TRIAL_KEY");
+    public static final Material VAULT = get("VAULT");
+    public static final Material TRIAL_SPAWNER = get("TRIAL_SPAWNER");
+    public static final Material HEAVY_CORE = get("HEAVY_CORE");
+    public static final Material MACE = get("MACE");
+    public static final Material WOLF_ARMOR = get("WOLF_ARMOR");
+    public static final Material CRAFTER = get("CRAFTER");
+    public static final Material COPPER_BULB = get("COPPER_BULB");
+    public static final Material BREEZE_SPAWN_EGG = get("BREEZE_SPAWN_EGG");
+
+    @Nullable
+    private static Material get(@Nonnull String name) {
+        return Material.matchMaterial(name);
+    }
+}

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/TestAutoBrewerPotions.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/TestAutoBrewerPotions.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 
 import io.github.thebusybiscuit.slimefun4.implementation.items.electric.machines.AutoBrewer;
 import io.github.thebusybiscuit.slimefun4.utils.compatibility.VersionedPotionType;
+import io.github.thebusybiscuit.slimefun4.utils.compatibility.VersionedMaterial;
 
 class TestAutoBrewerPotions {
 
@@ -30,11 +31,10 @@ class TestAutoBrewerPotions {
         assertEquals(VersionedPotionType.WEAVING, recipes.get(Material.COBWEB));
         assertEquals(VersionedPotionType.INFESTED, recipes.get(Material.STONE));
 
-        Material breezeRod = Material.matchMaterial("BREEZE_ROD");
-        if (breezeRod != null) {
-            assertEquals(VersionedPotionType.WIND_CHARGED, recipes.get(breezeRod));
+        if (VersionedMaterial.BREEZE_ROD != null) {
+            assertEquals(VersionedPotionType.WIND_CHARGED, recipes.get(VersionedMaterial.BREEZE_ROD));
         } else {
-            assertNotNull(breezeRod, "BREEZE_ROD material should exist on 1.21");
+            assertNotNull(VersionedMaterial.BREEZE_ROD, "BREEZE_ROD material should exist on 1.21");
         }
     }
 }


### PR DESCRIPTION
## Summary
- add VersionedMaterial utility to safely reference 1.21-specific items
- refactor machines and listeners to use centralized material lookups
- expose new 1.21 item stacks via VersionedMaterial in SlimefunItems

## Testing
- `mvn -q test` *(fails: NoClassDefFound errors and test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6b6bd958832cbd939f7e93072800