### PR TITLE
Fix SlimefunItemStack clone recursion

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItemStack.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/items/SlimefunItemStack.java
@@ -307,7 +307,12 @@ public class SlimefunItemStack extends ItemStack {
 
     @Override
     public ItemStack clone() {
-        return new SlimefunItemStack(id, this);
+        // Use the parent implementation to create a plain ItemStack copy first.
+        // This avoids the ItemStack(ItemStack) constructor recursively calling
+        // clone() on SlimefunItemStack which previously resulted in a
+        // StackOverflowError during tests.
+        ItemStack copy = super.clone();
+        return new SlimefunItemStack(id, copy);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- avoid recursive StackOverflow in `SlimefunItemStack.clone()` by cloning the parent `ItemStack` first

## Testing
- `mvn -q -Dtest=TestDeathpointListener test`
- `mvn -q -Dtest=TestSlimefunItemInteractListener test`
- `mvn -q test` *(fails: TestSmithingTableListener NPE, UpdaterService build check)*

------
https://chatgpt.com/codex/tasks/task_e_68bd70afb68c832c9916eb356554827c