### PR TITLE
Improve updater configuration handling

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/UpdaterService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/UpdaterService.java
@@ -90,6 +90,12 @@ public class UpdaterService {
         this.updater = autoUpdater;
     }
 
+    UpdaterService(@Nonnull Slimefun plugin, PluginUpdater<PrefixedVersion> updater, SlimefunBranch branch) {
+        this.plugin = plugin;
+        this.updater = updater;
+        this.branch = branch;
+    }
+
     /**
      * This method returns the branch the current build of Slimefun is running on.
      * This can be used to determine whether we are dealing with an official build
@@ -132,12 +138,15 @@ public class UpdaterService {
     }
 
     public boolean isLatestVersion() {
-        if (getBuildNumber() == -1 || getLatestVersion() == -1) {
+        int current = getBuildNumber();
+        int latest = getLatestVersion();
+
+        if (current == -1 || latest == -1) {
             // We don't know if we're latest so just report we are
             return true;
         }
-        
-        return getBuildNumber() == getLatestVersion();
+
+        return current == latest;
     }
 
     /**

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/core/services/TestUpdaterService.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/core/services/TestUpdaterService.java
@@ -8,10 +8,13 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import io.github.bakedlibs.dough.updater.PluginUpdater;
+import io.github.bakedlibs.dough.versions.PrefixedVersion;
 import io.github.thebusybiscuit.slimefun4.api.SlimefunBranch;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 
 import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockito.Mockito;
 
 class TestUpdaterService {
 
@@ -66,5 +69,18 @@ class TestUpdaterService {
         Assertions.assertEquals(SlimefunBranch.UNKNOWN, service.getBranch());
         Assertions.assertFalse(service.getBranch().isOfficial());
         Assertions.assertEquals(-1, service.getBuildNumber());
+    }
+
+    @Test
+    @DisplayName("Test if auto-update config is respected")
+    void testAutoUpdateConfig() {
+        PluginUpdater<PrefixedVersion> updater = Mockito.mock(PluginUpdater.class);
+        UpdaterService service = new UpdaterService(plugin, updater, SlimefunBranch.DEVELOPMENT);
+
+        Slimefun.getCfg().setValue("options.auto-update", false);
+        Assertions.assertFalse(service.isEnabled());
+
+        Slimefun.getCfg().setValue("options.auto-update", true);
+        Assertions.assertTrue(service.isEnabled());
     }
 }


### PR DESCRIPTION
## Summary
- Refactor updater version comparison to avoid repeated lookups and consolidate update checking logic
- Allow injecting a custom PluginUpdater for easier testing and configurability
- Add unit test ensuring updater respects auto-update config setting

## Testing
- `mvn -q test` *(fails: see logs above; attempts to run full suite but includes environmental warnings)*
- `mvn -Dtest=TestUpdaterService test`

------
https://chatgpt.com/codex/tasks/task_e_68bd841213e8832c80fdc616ab7b9c84