### PR TITLE
Parse build number in UpdaterService without updater

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/UpdaterService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/UpdaterService.java
@@ -1,13 +1,14 @@
 package io.github.thebusybiscuit.slimefun4.core.services;
 
 import java.io.File;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
 
 import javax.annotation.Nonnull;
 
 import io.github.bakedlibs.dough.updater.BlobBuildUpdater;
-import org.bukkit.plugin.Plugin;
 
 import io.github.bakedlibs.dough.config.Config;
 import io.github.bakedlibs.dough.updater.PluginUpdater;
@@ -36,6 +37,13 @@ public class UpdaterService {
     private final PluginUpdater<PrefixedVersion> updater;
 
     /**
+     * The version string passed to this service.
+     */
+    private final String version;
+
+    private static final Pattern BUILD_PATTERN = Pattern.compile("^(?:Dev|RC) - (\\d+)");
+
+    /**
      * The {@link SlimefunBranch} we are currently on.
      * If this is an official {@link SlimefunBranch}, auto updates will be enabled.
      */
@@ -54,6 +62,7 @@ public class UpdaterService {
      */
     public UpdaterService(@Nonnull Slimefun plugin, @Nonnull String version, @Nonnull File file) {
         this.plugin = plugin;
+        this.version = version;
         BlobBuildUpdater autoUpdater = null;
 
         if (version.contains("UNOFFICIAL")) {
@@ -109,9 +118,9 @@ public class UpdaterService {
      * @return The build number of this Slimefun.
      */
     public int getBuildNumber() {
-        if (updater != null) {
-            PrefixedVersion version = updater.getCurrentVersion();
-            return version.getVersionNumber();
+        Matcher matcher = BUILD_PATTERN.matcher(version);
+        if (matcher.find()) {
+            return Integer.parseInt(matcher.group(1));
         }
 
         return -1;

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/core/services/TestUpdaterService.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/core/services/TestUpdaterService.java
@@ -36,8 +36,7 @@ class TestUpdaterService {
         UpdaterService service = new UpdaterService(plugin, "Dev - 131 (git 123456)", file);
         Assertions.assertEquals(SlimefunBranch.DEVELOPMENT, service.getBranch());
         Assertions.assertTrue(service.getBranch().isOfficial());
-        // Cannot currently be tested... yay
-        // Assertions.assertEquals(131, service.getBuildNumber());
+        Assertions.assertEquals(131, service.getBuildNumber());
     }
 
     @Test
@@ -46,8 +45,15 @@ class TestUpdaterService {
         UpdaterService service = new UpdaterService(plugin, "RC - 6 (git 123456)", file);
         Assertions.assertEquals(SlimefunBranch.STABLE, service.getBranch());
         Assertions.assertTrue(service.getBranch().isOfficial());
-        // Cannot currently be tested... yay
-        // Assertions.assertEquals(6, service.getBuildNumber());
+        Assertions.assertEquals(6, service.getBuildNumber());
+    }
+
+    @Test
+    @DisplayName("Test build parsing with invalid number")
+    void testInvalidBuildNumber() {
+        UpdaterService service = new UpdaterService(plugin, "Dev - abc", file);
+        Assertions.assertEquals(SlimefunBranch.DEVELOPMENT, service.getBranch());
+        Assertions.assertEquals(-1, service.getBuildNumber());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- parse build numbers directly from version string
- add tests covering build number parsing for development, stable, and invalid builds

## Testing
- `mvn test` *(fails: dependency download in progress; build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68bd841213e8832c80fdc616ab7b9c84