### PR TITLE
Notify players when hologram projector disappears mid-edit

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/HologramProjector.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/HologramProjector.java
@@ -106,7 +106,7 @@ public class HologramProjector extends SlimefunItem implements HologramOwner {
                 // Fixes #3445 - Make sure the projector is not broken
                 if (!BlockStorage.check(projector, getId())) {
                     // Hologram projector no longer exists.
-                    // TODO: Add a chat message informing the player that their message was ignored.
+                    Slimefun.getLocalization().sendMessage(pl, "machines.HOLOGRAM_PROJECTOR.projector-missing", true);
                     return;
                 }
 

--- a/src/main/resources/languages/ar/messages.yml
+++ b/src/main/resources/languages/ar/messages.yml
@@ -156,6 +156,7 @@ machines:
   HOLOGRAM_PROJECTOR:
     enter-text: '&7الرجاء كتابة النص المجسم في الشات. &r(رموز الألوان مدعومة!)'
     inventory-title: 'محرر النص المجسم'
+    projector-missing: '&4The hologram projector was removed before your message could be saved.'
   ELEVATOR:
     no-destinations: '&4لا يوجد وجهات'
     pick-a-floor: '&3- اختر طابق -'

--- a/src/main/resources/languages/bg/messages.yml
+++ b/src/main/resources/languages/bg/messages.yml
@@ -251,6 +251,7 @@ machines:
   HOLOGRAM_PROJECTOR:
     enter-text: '&7Моля въведете желания текст за Хологрмата във вашият чат. &r(Цветовите Кодове са поддържани!)'
     inventory-title: 'Редактор на Холограми'
+    projector-missing: '&4The hologram projector was removed before your message could be saved.'
   ELEVATOR:
     no-destinations: '&4Нямаше намерени дестинации'
     pick-a-floor: '&3- Изберете Етаж -'

--- a/src/main/resources/languages/cs/messages.yml
+++ b/src/main/resources/languages/cs/messages.yml
@@ -251,6 +251,7 @@ machines:
   HOLOGRAM_PROJECTOR:
     enter-text: '&7Napiš do chatu zprávu, kterou chceš, aby hologram ukazoval. &r(Barvy jsou podporovány!)'
     inventory-title: 'Editor hologramu'
+    projector-missing: '&4The hologram projector was removed before your message could be saved.'
   ELEVATOR:
     no-destinations: '&4Žádné destinace nebyly nalezeny'
     pick-a-floor: '&3- Vyber si patro -'

--- a/src/main/resources/languages/de/messages.yml
+++ b/src/main/resources/languages/de/messages.yml
@@ -254,6 +254,7 @@ machines:
   HOLOGRAM_PROJECTOR:
     enter-text: '&7Bitte gebe ins Chatfenser einen Text für dieses Hologram ein. &r(Farbcodes werden unterstützt!)'
     inventory-title: 'Hologrammeditor'
+    projector-missing: '&4The hologram projector was removed before your message could be saved.'
   ELEVATOR:
     no-destinations: '&4Es konnten keine weiteren Etagen gefunden werden'
     pick-a-floor: '&3- Wähle eine Etage -'

--- a/src/main/resources/languages/en/messages.yml
+++ b/src/main/resources/languages/en/messages.yml
@@ -316,6 +316,7 @@ machines:
   HOLOGRAM_PROJECTOR:
     enter-text: '&7Please enter your desired Hologram Text into your Chat. &r(Color Codes are supported!)'
     inventory-title: 'Hologram Editor'
+    projector-missing: '&4The hologram projector was removed before your message could be saved.'
 
   ELEVATOR:
     no-destinations: '&4No destinations found'

--- a/src/main/resources/languages/es/messages.yml
+++ b/src/main/resources/languages/es/messages.yml
@@ -251,6 +251,7 @@ machines:
   HOLOGRAM_PROJECTOR:
     enter-text: '&7Por favor, escribe en el chat el texto deseado. &r(¡Se permiten códigos de color!)'
     inventory-title: 'Editor de Holograma'
+    projector-missing: '&4The hologram projector was removed before your message could be saved.'
   ELEVATOR:
     no-destinations: '&4No se han encontrado destinos.'
     pick-a-floor: '&3- Selecciona un piso -'

--- a/src/main/resources/languages/fa/messages.yml
+++ b/src/main/resources/languages/fa/messages.yml
@@ -87,6 +87,7 @@ messages:
 machines:
   HOLOGRAM_PROJECTOR:
     inventory-title: 'ویرایشگر هولوگرام'
+    projector-missing: '&4The hologram projector was removed before your message could be saved.'
   ELEVATOR:
     no-destinations: '&4مقصدی پیدا نشد'
   TELEPORTER:

--- a/src/main/resources/languages/fr/messages.yml
+++ b/src/main/resources/languages/fr/messages.yml
@@ -255,6 +255,7 @@ machines:
   HOLOGRAM_PROJECTOR:
     enter-text: '&7Veuillez saisir le texte voulu pour votre hologramme dans le chat. &r(Les codes couleur sont acceptés !)'
     inventory-title: 'Éditeur d''hologramme'
+    projector-missing: '&4The hologram projector was removed before your message could be saved.'
   ELEVATOR:
     no-destinations: '&4Aucune destination trouvée'
     pick-a-floor: '&3- Sélectionnez un étage -'

--- a/src/main/resources/languages/he/messages.yml
+++ b/src/main/resources/languages/he/messages.yml
@@ -255,6 +255,7 @@ machines:
   HOLOGRAM_PROJECTOR:
     enter-text: '&7אנא הכנס את  טקסט ההולוגרמה לצ''ט שלך. &r( קודי צבע נתמכים!)'
     inventory-title: 'עורך הולוגרמה'
+    projector-missing: '&4The hologram projector was removed before your message could be saved.'
   ELEVATOR:
     no-destinations: '&4לא נמצאו יעדים '
     pick-a-floor: '&3- בחר קומה -'

--- a/src/main/resources/languages/hu/messages.yml
+++ b/src/main/resources/languages/hu/messages.yml
@@ -256,6 +256,7 @@ machines:
   HOLOGRAM_PROJECTOR:
     enter-text: '&7Kérlek, írd be a kívánt hologram szöveget a chatre. &r(Színkódok is használhatóak!)'
     inventory-title: 'Hologram szerkesztő'
+    projector-missing: '&4The hologram projector was removed before your message could be saved.'
   ELEVATOR:
     no-destinations: '&4Nem található úticél'
     pick-a-floor: '&3- Válassz emeletet -'

--- a/src/main/resources/languages/id/messages.yml
+++ b/src/main/resources/languages/id/messages.yml
@@ -186,6 +186,7 @@ machines:
   HOLOGRAM_PROJECTOR:
     enter-text: '&7Masukan teks sesuai yang anda inginkan. &r(Mendukung warna teks!)'
     inventory-title: 'Pengedit hologram'
+    projector-missing: '&4The hologram projector was removed before your message could be saved.'
   ELEVATOR:
     no-destinations: '&4Tujuan tidak ditemukan'
     pick-a-floor: '&3- Pilih Lantai -'

--- a/src/main/resources/languages/ja/messages.yml
+++ b/src/main/resources/languages/ja/messages.yml
@@ -253,6 +253,7 @@ machines:
   HOLOGRAM_PROJECTOR:
     enter-text: '&7指定したい文字列をチャットに入力してください&r（カラーコード対応）'
     inventory-title: 'ホログラムエディタ'
+    projector-missing: '&4The hologram projector was removed before your message could be saved.'
   ELEVATOR:
     no-destinations: '&4他の階が見つかりません'
     pick-a-floor: '&3- 行先の選択 -'

--- a/src/main/resources/languages/ko/messages.yml
+++ b/src/main/resources/languages/ko/messages.yml
@@ -172,6 +172,7 @@ machines:
   HOLOGRAM_PROJECTOR:
     enter-text: '&7원하는 홀로그램 텍스트를 대화 상자에 입력해 주십시오. &r(색상 코드가 지원됨!)'
     inventory-title: '홀로그램 편집기'
+    projector-missing: '&4The hologram projector was removed before your message could be saved.'
   ELEVATOR:
     no-destinations: "&4대상을 찾을 수 없습니다.\n"
     pick-a-floor: "&3- 바닥을 고르세요 -\n"

--- a/src/main/resources/languages/nl/messages.yml
+++ b/src/main/resources/languages/nl/messages.yml
@@ -252,6 +252,7 @@ machines:
   HOLOGRAM_PROJECTOR:
     enter-text: '&7Type astublieft de gewenste text in het gespreksvenster. &r(Kleurcodes zijn ondersteund)'
     inventory-title: 'Hologram-editor'
+    projector-missing: '&4The hologram projector was removed before your message could be saved.'
   ELEVATOR:
     no-destinations: '&4Geen doelen gevonden'
     pick-a-floor: '&3- Kies een verdieping -'

--- a/src/main/resources/languages/pl/messages.yml
+++ b/src/main/resources/languages/pl/messages.yml
@@ -171,6 +171,7 @@ machines:
   HOLOGRAM_PROJECTOR:
     enter-text: '&7Wprowadź żądany tekst hologramu na czacie. &r(Kody kolorów są obsługiwane!)'
     inventory-title: 'Edytor hologramów'
+    projector-missing: '&4The hologram projector was removed before your message could be saved.'
   ELEVATOR:
     no-destinations: '&4Nie znaleziono miejsc docelowych'
     pick-a-floor: '&3- Wybierz piętro-'

--- a/src/main/resources/languages/pt-BR/messages.yml
+++ b/src/main/resources/languages/pt-BR/messages.yml
@@ -198,6 +198,7 @@ machines:
   HOLOGRAM_PROJECTOR:
     enter-text: '&7Digite o nome do holograma no bate-papo. &r(Códigos de cores são suportados!)'
     inventory-title: 'Editor de Holograma'
+    projector-missing: '&4The hologram projector was removed before your message could be saved.'
   ELEVATOR:
     no-destinations: '&4Nenhum destino encontrado!'
     pick-a-floor: '&3- Escolha um andar -'

--- a/src/main/resources/languages/pt/messages.yml
+++ b/src/main/resources/languages/pt/messages.yml
@@ -168,6 +168,7 @@ machines:
     unknown-recipe: '&4Receita desconhecida! &cUsa a receita correta!'
   HOLOGRAM_PROJECTOR:
     inventory-title: 'Editor de Holograma'
+    projector-missing: '&4The hologram projector was removed before your message could be saved.'
   ELEVATOR:
     no-destinations: '&4Não foram encontrados destinos'
     pick-a-floor: '&3- Escolha um piso -'

--- a/src/main/resources/languages/ru/messages.yml
+++ b/src/main/resources/languages/ru/messages.yml
@@ -224,6 +224,7 @@ machines:
   HOLOGRAM_PROJECTOR:
     enter-text: '&7Пожалуйста, введите желаемый текст для голограммы в чат. &r(можно использовать цветовые коды!)'
     inventory-title: 'Редактирование голограммы'
+    projector-missing: '&4The hologram projector was removed before your message could be saved.'
   ELEVATOR:
     no-destinations: '&4Этажи не найдены'
     pick-a-floor: '&3- Выберите пункт назначения -'

--- a/src/main/resources/languages/sk/messages.yml
+++ b/src/main/resources/languages/sk/messages.yml
@@ -153,6 +153,7 @@ machines:
   HOLOGRAM_PROJECTOR:
     enter-text: '&7Prosím napíš text pre hologram do chatu. &r(Kódy farieb sú podporované!)'
     inventory-title: 'Editor hologramu'
+    projector-missing: '&4The hologram projector was removed before your message could be saved.'
   ELEVATOR:
     no-destinations: '&4Nenájdený žiaden cieľ'
     pick-a-floor: '&3- Výber podlažia  -'

--- a/src/main/resources/languages/sv/messages.yml
+++ b/src/main/resources/languages/sv/messages.yml
@@ -158,6 +158,7 @@ machines:
   HOLOGRAM_PROJECTOR:
     enter-text: '&7Skriv in önskad hologramtext i chatten &r(färgkoder stöds!)'
     inventory-title: 'Hologramändrare'
+    projector-missing: '&4The hologram projector was removed before your message could be saved.'
   ELEVATOR:
     no-destinations: '&4Ingen destination funnen'
     pick-a-floor: '&3- Välj en våning -'

--- a/src/main/resources/languages/th/messages.yml
+++ b/src/main/resources/languages/th/messages.yml
@@ -145,6 +145,7 @@ machines:
   HOLOGRAM_PROJECTOR:
     enter-text: '&7โปรดพิมพ์ข้อความที่คุณต้องการแสดง Hologram ในแชท. &r(รองรับรหัสสี!)'
     inventory-title: 'แก้ไข Hologram'
+    projector-missing: '&4The hologram projector was removed before your message could be saved.'
   ELEVATOR:
     no-destinations: '&4ไม่พบจุดหมาย'
     pick-a-floor: '&3- เลือกชั้น -'

--- a/src/main/resources/languages/tr/messages.yml
+++ b/src/main/resources/languages/tr/messages.yml
@@ -239,6 +239,7 @@ machines:
   HOLOGRAM_PROJECTOR:
     enter-text: '&7Lütfen Sohbette istediğiniz Hologram Metnini yazın. &r(Renk Kodları destekleniyor!)'
     inventory-title: 'Hologram Editörü'
+    projector-missing: '&4The hologram projector was removed before your message could be saved.'
   ELEVATOR:
     no-destinations: '&4Varış noktası bulunamadı'
     pick-a-floor: '&3- Bir kat seçin -'

--- a/src/main/resources/languages/uk/messages.yml
+++ b/src/main/resources/languages/uk/messages.yml
@@ -154,6 +154,7 @@ machines:
   HOLOGRAM_PROJECTOR:
     enter-text: '&7Будь ласка, введіть бажаний текст для голограми в чат. &r(кольори підтримуються!)'
     inventory-title: 'Редагування голограми'
+    projector-missing: '&4The hologram projector was removed before your message could be saved.'
   ELEVATOR:
     no-destinations: '&4Поверхи не знайдено'
     pick-a-floor: '&3- Виберіть поверх -'

--- a/src/main/resources/languages/vi/messages.yml
+++ b/src/main/resources/languages/vi/messages.yml
@@ -201,6 +201,7 @@ machines:
   HOLOGRAM_PROJECTOR:
     enter-text: '&7Vui lòng nhập Văn Bản Ba Chiều mong muốn của bạn vào Khung trò chuyện. &r(Mã màu được hỗ trợ!)'
     inventory-title: 'Trình chỉnh sửa ảnh ba chiều'
+    projector-missing: '&4The hologram projector was removed before your message could be saved.'
   ELEVATOR:
     no-destinations: '&4Không tìm thấy điểm đến'
     pick-a-floor: '&4- Chọn một tầng -'

--- a/src/main/resources/languages/zh-CN/messages.yml
+++ b/src/main/resources/languages/zh-CN/messages.yml
@@ -276,6 +276,7 @@ machines:
   HOLOGRAM_PROJECTOR:
     enter-text: '&7请写下想显示在全息文本上的话. &r(支持颜色代码)'
     inventory-title: '全息图像编辑器'
+    projector-missing: '&4The hologram projector was removed before your message could be saved.'
   ELEVATOR:
     no-destinations: '&4找不到上下楼'
     pick-a-floor: '&3- 选择一个楼层 -'

--- a/src/main/resources/languages/zh-TW/messages.yml
+++ b/src/main/resources/languages/zh-TW/messages.yml
@@ -252,6 +252,7 @@ machines:
   HOLOGRAM_PROJECTOR:
     enter-text: '&7請輸入你想要顯示的文字訊息。 &r（可以輸入顏色代碼）'
     inventory-title: '全息投影編輯器'
+    projector-missing: '&4The hologram projector was removed before your message could be saved.'
   ELEVATOR:
     no-destinations: '&4找不到目的地'
     pick-a-floor: '&3- 選擇樓層 -'


### PR DESCRIPTION
## Summary
- send a localized warning when a hologram projector vanishes before saving chat input
- add the new `projector-missing` translation entry to all language files so the warning can be displayed everywhere

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1a68dca68832c890070ec22b32f2c